### PR TITLE
Add `discriminator` keyword support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning].
 ### Added
 
 - Add `minitest` and `rake-test` support. ([@skryukov])
+- Add `discriminator` keyword support. ([@skryukov])
 
 ## [0.1.0] - 2023-09-27
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ end
 
 - Full support for external `$ref`s
 - Full OpenAPI 3.1.0 support:
-  - `discriminator` keyword
   - respect `style` and `explode` keywords
   - xml
 - Callbacks and webhooks validations

--- a/lib/skooma/dialects/oas_3_1.rb
+++ b/lib/skooma/dialects/oas_3_1.rb
@@ -12,6 +12,8 @@ module Skooma
 
           registry.add_vocabulary(
             "https://spec.openapis.org/oas/3.1/vocab/base",
+            Skooma::Keywords::OAS31::Dialect::AnyOf,
+            Skooma::Keywords::OAS31::Dialect::OneOf,
             Skooma::Keywords::OAS31::Dialect::Discriminator,
             Skooma::Keywords::OAS31::Dialect::Xml,
             Skooma::Keywords::OAS31::Dialect::ExternalDocs,

--- a/lib/skooma/keywords/oas_3_1/dialect/any_of.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/any_of.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Skooma
+  module Keywords
+    module OAS31
+      module Dialect
+        class AnyOf < JSONSkooma::Keywords::Applicator::AnyOf
+          self.key = "anyOf"
+          self.value_schema = :array_of_schemas
+          self.depends_on = %w[discriminator]
+
+          def evaluate(instance, result)
+            discriminator_schema = result.sibling(instance, "discriminator")&.annotation
+            reorder_json(discriminator_schema)
+
+            super
+          end
+
+          private
+
+          def reorder_json(discriminator_schema)
+            return unless discriminator_schema
+
+            first = @json.delete_at(@json.index { |schema| resolve_uri(schema["$ref"]) == discriminator_schema })
+            @json.unshift first if first
+          end
+
+          def resolve_uri(uri)
+            uri = URI.parse(uri)
+            return uri if uri.absolute?
+
+            parent_schema.base_uri + uri if parent_schema.base_uri
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/skooma/keywords/oas_3_1/dialect/discriminator.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/discriminator.rb
@@ -4,8 +4,39 @@ module Skooma
   module Keywords
     module OAS31
       module Dialect
-        class Discriminator < JSONSkooma::Keywords::BaseAnnotation
+        # Discriminator keyword is an annotation keyword,
+        # it does not affect validation of allOf/anyOf/oneOf schemas.
+        # See https://github.com/OAI/OpenAPI-Specification/pull/2618
+        class Discriminator < JSONSkooma::Keywords::Base
           self.key = "discriminator"
+
+          def evaluate(instance, result)
+            value = instance[json["propertyName"]]
+            uri = mapped_uri(value)
+            return result.failure("Could not resolve discriminator for value `#{value.inspect}`") if uri.nil?
+
+            parent_schema.registry.schema(
+              uri,
+              metaschema_uri: parent_schema.metaschema_uri,
+              cache_id: parent_schema.cache_id
+            )
+            result.annotate(uri)
+          rescue JSONSkooma::RegistryError => e
+            result.failure("Could not resolve discriminator mapping: #{e.message}")
+          end
+
+          private
+
+          def mapped_uri(value)
+            uri = json["mapping"]&.fetch(value, value)
+            return if uri.nil?
+
+            uri = "#/components/schemas/#{uri}" unless uri.start_with?("#") || uri.include?("/")
+            uri = URI.parse(uri)
+            return uri if uri.absolute?
+
+            parent_schema.base_uri + uri if parent_schema.base_uri
+          end
         end
       end
     end

--- a/lib/skooma/keywords/oas_3_1/dialect/one_of.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/one_of.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Skooma
+  module Keywords
+    module OAS31
+      module Dialect
+        class OneOf < JSONSkooma::Keywords::Applicator::OneOf
+          self.key = "oneOf"
+          self.value_schema = :array_of_schemas
+          self.depends_on = %w[discriminator]
+
+          def evaluate(instance, result)
+            discriminator_schema = result.sibling(instance, "discriminator")&.annotation
+            reorder_json(discriminator_schema)
+
+            super
+          end
+
+          private
+
+          def reorder_json(discriminator_schema)
+            return unless discriminator_schema
+
+            first = @json.delete_at(@json.index { |schema| resolve_uri(schema["$ref"]) == discriminator_schema })
+            @json.unshift first if first
+          end
+
+          def resolve_uri(uri)
+            uri = URI.parse(uri)
+            return uri if uri.absolute?
+
+            parent_schema.base_uri + uri if parent_schema.base_uri
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/openapi_test_suite/discriminator.json
+++ b/spec/openapi_test_suite/discriminator.json
@@ -1,0 +1,213 @@
+[
+  {
+    "description": "Discriminator",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/Cat"
+                        },
+                        {
+                          "$ref": "#/components/schemas/Doggy"
+                        },
+                        {
+                          "$ref": "#/components/schemas/CuteHamster"
+                        }
+                      ],
+                      "discriminator": {
+                        "propertyName": "kind",
+                        "mapping": {
+                          "Dog": "#/components/schemas/Doggy",
+                          "Hamster": "CuteHamster"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Pet": {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string"
+              }
+            }
+          },
+          "Cat": {
+            "unevaluatedProperties": false,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Pet"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "color": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "Doggy": {
+            "unevaluatedProperties": false,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Pet"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "breed": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "CuteHamster": {
+            "unevaluatedProperties": false,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Pet"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cuteness": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "response with valid discriminator",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"color\": \"black\", \"kind\": \"Cat\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "response with valid mapped discriminator",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"breed\": \"pug\", \"kind\": \"Dog\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "response with valid mapped name-only discriminator",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"cuteness\": 9000, \"kind\": \"Hamster\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "response with unknown discriminator",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"kind\": \"Unicorn\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "response without discriminator value",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"foo\": \"bar\"}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds initial `discriminator` keyword support.

According to a not-yet-released update to the specification (https://github.com/OAI/OpenAPI-Specification/pull/2618), the `discriminator` keyword is an annotation keyword, that SHOULD fail the validation when no schema can be determined.

We also use `discriminator` keyword annotation in `anyOf` and `oneOf` keywords to reorder the list of schemas, which might increase performance of validation later with introduction of short circuit errors.