### PR TITLE
Fix zeitwerk eager loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning].
 - Add `minitest` and `rake-test` support. ([@skryukov])
 - Add `discriminator` keyword support. ([@skryukov])
 
+### Fixed
+
+- Fix Zeitwerk eager loading. ([@skryukov])
+
 ## [0.1.0] - 2023-09-27
 
 ### Added

--- a/lib/skooma.rb
+++ b/lib/skooma.rb
@@ -6,7 +6,7 @@ require "zeitwerk"
 require_relative "skooma/inflector"
 
 loader = Zeitwerk::Loader.for_gem
-loader.inflector = Skooma::Inflector.new
+loader.inflector = Skooma::Inflector.new(__FILE__)
 loader.setup
 
 module Skooma

--- a/lib/skooma/inflector.rb
+++ b/lib/skooma/inflector.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Skooma
-  class Inflector < Zeitwerk::Inflector
+  class Inflector < Zeitwerk::GemInflector
     STATIC_MAPPING = {
       "oas_3_1" => "OAS31",
       "openapi" => "OpenAPI",

--- a/skooma.gemspec
+++ b/skooma.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
-  spec.add_runtime_dependency "json_skooma", "~> 0.1"
+  spec.add_runtime_dependency "json_skooma", "~> 0.2"
 end


### PR DESCRIPTION
This PR fixes zeitwerk eager loading and upgrades `json_skooma` version with the fixed problem.

Fixes #3 