### PR TITLE
Fix methods shadowing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,5 +50,9 @@ jobs:
         run: bundle exec rspec
       - name: Run RSpec examples
         run: CI=1 ruby examples/rspec.rb
+      - name: Fix RubyGems activating older versions of gems
+        run: gem install timeout net-protocol stringio psych date
+      - name: Run RSpec Rails examples
+        run: CI=1 ruby examples/rspec_rails.rb
       - name: Run minitest example
         run: CI=1 ruby examples/minitest.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Better checks to automatic request/response detection to prevent methods overrides via RSpec helpers (i.e. `subject(:response)`). ([@skryukov])
+
 ## [0.2.1] - 2023-10-23
 
 ### Fixed

--- a/examples/minitest.rb
+++ b/examples/minitest.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib")) if ENV["CI"] == "1"
-
 require "bundler/inline"
 
 gemfile do
   source "https://rubygems.org"
   gem "minitest"
   gem "rack-test"
-  gem "skooma"
+  gem "skooma", (ENV["CI"] == "1") ? {path: File.join(__dir__, "..")} : {}
   gem "sinatra"
 end
 

--- a/lib/skooma/matchers/conform_response_schema.rb
+++ b/lib/skooma/matchers/conform_response_schema.rb
@@ -19,7 +19,7 @@ module Skooma
       end
 
       def failure_message
-        return "Expected #{@expected} status code" unless status_matches?
+        return "Expected #{@expected} status code, but got #{@mapped_response["response"]["status"]}" unless status_matches?
 
         super
       end

--- a/lib/skooma/matchers/wrapper.rb
+++ b/lib/skooma/matchers/wrapper.rb
@@ -23,18 +23,18 @@ module Skooma
 
         def request_object
           # `rails` integration
-          return request if defined?(::ActionDispatch)
+          return @request if defined?(::ActionDispatch) && @request.is_a?(::ActionDispatch::Request)
           # `rack-test` integration
-          return last_request if defined?(::Rack::Test)
+          return last_request if defined?(::Rack::Test) && defined?(:last_request)
 
           raise "Request object not found"
         end
 
         def response_object
           # `rails` integration
-          return response if defined?(::ActionDispatch)
+          return @response if defined?(::ActionDispatch) && @response.is_a?(::ActionDispatch::Response)
           # `rack-test` integration
-          return last_response if defined?(::Rack::Test)
+          return last_response if defined?(::Rack::Test) && defined?(:last_response)
 
           raise "Response object not found"
         end


### PR DESCRIPTION
This PR adds better checks to automatic request/response detection to prevent methods overrides via RSpec helpers (i.e. `subject(:response)`).

Fixes #7