### PR TITLE
Fail response validation without expected response code or `responses` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning].
 ### Fixed
 
 - Better checks to automatic request/response detection to prevent methods overrides via RSpec helpers (i.e. `subject(:response)`). ([@skryukov])
+- Fail response validation when expected response code or `responses` keyword aren't listed. ([@skryukov])
 
 ## [0.2.1] - 2023-10-23
 

--- a/lib/skooma/objects/openapi/keywords/paths.rb
+++ b/lib/skooma/objects/openapi/keywords/paths.rb
@@ -32,7 +32,7 @@ module Skooma
               subresult.annotate({"path_attributes" => attributes})
               path_schema.evaluate(instance, subresult)
 
-              if subresult.passed?
+              if subresult.passed? && subresult.children.any?
                 result.success
               else
                 result.failure("Path #{instance["path"]} is invalid")

--- a/lib/skooma/objects/path_item/keywords/base_operation.rb
+++ b/lib/skooma/objects/path_item/keywords/base_operation.rb
@@ -8,6 +8,10 @@ module Skooma
           def evaluate(instance, result)
             return result.discard unless instance["method"] == key
 
+            if json["responses"].nil? && instance["response"]
+              return result.failure("Responses are not listed for #{key.upcase} #{instance["path"]}")
+            end
+
             json.evaluate(instance, result)
             return result.success if result.passed?
 

--- a/spec/openapi_test_suite/meta_type_matches.json
+++ b/spec/openapi_test_suite/meta_type_matches.json
@@ -15,6 +15,7 @@
                 "application/json": {
                   "schema": {
                     "type": "object",
+                    "unevaluatedProperties": false,
                     "properties": {
                       "foo": {
                         "type": "string"
@@ -47,6 +48,7 @@
                   "application/json": {
                     "schema": {
                       "type": "object",
+                      "unevaluatedProperties": false,
                       "properties": {
                         "foo": {
                           "type": "string"

--- a/spec/openapi_test_suite/openapi_formats.json
+++ b/spec/openapi_test_suite/openapi_formats.json
@@ -17,6 +17,7 @@
                   "application/json": {
                     "schema": {
                       "type": "object",
+                      "unevaluatedProperties": false,
                       "properties": {
                         "int32": {
                           "format": "int32"

--- a/spec/openapi_test_suite/simple_routing.json
+++ b/spec/openapi_test_suite/simple_routing.json
@@ -17,6 +17,7 @@
                   "application/json": {
                     "schema": {
                       "type": "object",
+                      "unevaluatedProperties": false,
                       "properties": {
                         "foo": {
                           "type": "string"
@@ -38,6 +39,7 @@
                 "application/json": {
                   "schema": {
                     "type": "object",
+                    "unevaluatedProperties": false,
                     "properties": {
                       "foo": {
                         "type": "string"
@@ -57,6 +59,7 @@
                   "application/json": {
                     "schema": {
                       "type": "object",
+                      "unevaluatedProperties": false,
                       "properties": {
                         "foo": {
                           "type": "string"
@@ -75,6 +78,7 @@
                   "application/json": {
                     "schema": {
                       "type": "object",
+                      "unevaluatedProperties": false,
                       "properties": {
                         "message": {
                           "type": "string"
@@ -111,6 +115,59 @@
                   }
                 }
               }
+            },
+            "responses": {
+              "200": {
+                "description": "OK",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Foo"
+                    }
+                  }
+                }
+              },
+              "422": {
+                "description": "Unprocessable Entity",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "unevaluatedProperties": false,
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/no_responses": {
+          "get": {}
+        },
+        "/with_default_response": {
+          "get": {
+            "responses": {
+              "default": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "unevaluatedProperties": false,
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -119,6 +176,7 @@
         "schemas": {
           "Foo": {
             "type": "object",
+            "unevaluatedProperties": false,
             "properties": {
               "foo": {
                 "type": "string"
@@ -290,6 +348,103 @@
               "Content-Type": "application/json"
             },
             "body": "{\"message\": \"validation error\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with default response",
+        "data": {
+          "method": "get",
+          "path": "/with_default_response",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"message\": \"ok\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "undocumented route path",
+        "data": {
+          "method": "get",
+          "path": "/unknown_path",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 404
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "undocumented route method",
+        "data": {
+          "method": "patch",
+          "path": "/simple_with_ref",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 404
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "undocumented route response code",
+        "data": {
+          "method": "post",
+          "path": "/simple_with_ref",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 418
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "no responses in schema",
+        "data": {
+          "method": "get",
+          "path": "/no_responses",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
+          },
+          "response": {
+            "status": 418
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "no responses in schema request only",
+        "data": {
+          "method": "get",
+          "path": "/no_responses",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            }
           }
         },
         "valid": true

--- a/spec/openapi_test_suite/template_routes.json
+++ b/spec/openapi_test_suite/template_routes.json
@@ -123,6 +123,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "unevaluatedProperties": false,
                   "properties": {
                     "foo": {
                       "type": "string"


### PR DESCRIPTION
This PR makes validation to fail when expected response code or `responses` keyword aren't listed.