### PR TITLE
Add support for APIs mounted under a path prefix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run StandardRB
         run: bundle exec standardrb
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
@@ -40,7 +41,7 @@ jobs:
           - "jruby"
           - "truffleruby"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+
+### Added
+
+- Add support for APIs mounted under a path prefix. ([@skryukov])
+
+```ruby
+# spec/rails_helper.rb
+
+RSpec.configure do |config|
+  # ...
+  path_to_openapi = Rails.root.join("docs", "openapi.yml")
+  # pass path_prefix option if your API is mounted under a prefix:
+  config.include Skooma::RSpec[path_to_openapi, path_prefix: "/internal/api"], type: :request
+end
+```
+
 ### Fixed
 
 - Better checks to automatic request/response detection to prevent methods overrides via RSpec helpers (i.e. `subject(:response)`). ([@skryukov])

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ RSpec.configure do |config|
   # ...
   path_to_openapi = Rails.root.join("docs", "openapi.yml")
   config.include Skooma::RSpec[path_to_openapi], type: :request
+
+  # OR pass path_prefix option if your API is mounted under a prefix:
+  config.include Skooma::RSpec[path_to_openapi, path_prefix: "/internal/api"], type: :request
 end
 ```
 

--- a/examples/rspec_rails.rb
+++ b/examples/rspec_rails.rb
@@ -25,7 +25,10 @@ ENV["RAILS_ENV"] = "test"
 
 RSpec.configure do |config|
   path_to_openapi = File.join(__dir__, "openapi.yml")
-  config.include Skooma::RSpec[path_to_openapi], type: :request
+  # You can use different RSpec filters if you want to test different API descriptions.
+  # Check RSpec's config.define_derived_metadata for better UX.
+  config.include Skooma::RSpec[path_to_openapi], :root_api, type: :request
+  config.include Skooma::RSpec[path_to_openapi, path_prefix: "/custom/path/to/api"], :prefixed_api, type: :request
 end
 
 class RailsApp < Rails::Application
@@ -35,40 +38,70 @@ class RailsApp < Rails::Application
 
   routes.append do
     mount TestApp, at: "/"
+    mount TestApp, at: "/custom/path/to/api", as: :prefixed_api
   end
 end
 
 RailsApp.initialize!
 
-describe "Rails app", type: :request do
+describe "Rails app" do
   describe "OpenAPI document", type: :request do
     subject(:schema) { skooma_openapi_schema }
 
     it { is_expected.to be_valid_document }
   end
 
-  describe "GET /" do
-    subject { get "/" }
+  describe "Prefixed API", :root_api, type: :request do
+    describe "GET /" do
+      subject { get "/" }
 
-    it { is_expected.to conform_schema(200) }
+      it { is_expected.to conform_schema(200) }
 
-    it "returns correct response" do
-      subject
-      expect(response.parsed_body).to eq({"foo" => "bar"})
+      it "returns correct response" do
+        subject
+        expect(response.parsed_body).to eq({"foo" => "bar"})
+      end
+    end
+
+    describe "POST /" do
+      subject { post("/", params: body, as: :json) }
+
+      let(:body) { {foo: "bar"} }
+
+      it { is_expected.to conform_schema(201) }
+
+      context "with invalid params" do
+        let(:body) { {foo: "baz"} }
+
+        it { is_expected.to conform_response_schema(400) }
+      end
     end
   end
 
-  describe "POST /" do
-    subject { post("/", params: body, as: :json) }
+  describe "Prefixed API", :prefixed_api, type: :request do
+    describe "GET prefixed /" do
+      subject { get "/custom/path/to/api" }
 
-    let(:body) { {foo: "bar"} }
+      it { is_expected.to conform_schema(200) }
 
-    it { is_expected.to conform_schema(201) }
+      it "returns correct response" do
+        subject
+        expect(response.parsed_body).to eq({"foo" => "bar"})
+      end
+    end
 
-    context "with invalid params" do
-      let(:body) { {foo: "baz"} }
+    describe "POST prefixed /" do
+      subject { post("/custom/path/to/api", params: body, as: :json) }
 
-      it { is_expected.to conform_response_schema(400) }
+      let(:body) { {foo: "bar"} }
+
+      it { is_expected.to conform_schema(201) }
+
+      context "with invalid params" do
+        let(:body) { {foo: "baz"} }
+
+        it { is_expected.to conform_response_schema(400) }
+      end
     end
   end
 end

--- a/lib/skooma/matchers/wrapper.rb
+++ b/lib/skooma/matchers/wrapper.rb
@@ -40,7 +40,7 @@ module Skooma
         end
       end
 
-      def initialize(helper_methods_module, openapi_path, base_uri: "https://skoomarb.dev/")
+      def initialize(helper_methods_module, openapi_path, base_uri: "https://skoomarb.dev/", path_prefix: "")
         super()
 
         registry = create_test_registry
@@ -50,6 +50,7 @@ module Skooma
           JSONSkooma::Sources::Local.new(pathname.dirname.to_s)
         )
         schema = registry.schema(URI.parse("#{base_uri}#{pathname.basename}"), schema_class: Skooma::Objects::OpenAPI)
+        schema.path_prefix = path_prefix
 
         include DefaultHelperMethods
         include helper_methods_module

--- a/lib/skooma/objects/openapi.rb
+++ b/lib/skooma/objects/openapi.rb
@@ -31,6 +31,18 @@ module Skooma
         super(Instance.new(instance), result)
       end
 
+      def path_prefix=(value)
+        raise ArgumentError, "Path prefix must be a string" unless value.is_a?(String)
+
+        @path_prefix = value
+        @path_prefix = "/#{@path_prefix}" unless @path_prefix.start_with?("/")
+        @path_prefix = @path_prefix.delete_suffix("/") if @path_prefix.end_with?("/")
+      end
+
+      def path_prefix
+        @path_prefix || ""
+      end
+
       def json_schema_dialect_uri
         @json_schema_dialect_uri || parent_schema&.json_schema_dialect_uri
       end

--- a/lib/skooma/objects/openapi/keywords/paths.rb
+++ b/lib/skooma/objects/openapi/keywords/paths.rb
@@ -43,6 +43,7 @@ module Skooma
           private
 
           def find_route(instance_path)
+            instance_path = instance_path.delete_prefix(json.root.path_prefix)
             return [instance_path, {}, json[instance_path]] if json.key?(instance_path)
 
             @regexp_map.reduce(nil) do |result, (path, path_regex, subschema)|

--- a/lib/skooma/objects/operation/keywords/parameters.rb
+++ b/lib/skooma/objects/operation/keywords/parameters.rb
@@ -12,7 +12,7 @@ module Skooma
           def initialize(parent_schema, value)
             super
             keys = json.filter_map { |v| v["in"] && [v["in"].value, v["name"].value] }
-            parent_params = (parent_schema.parent["parameters"] || [])
+            parent_params = parent_schema.parent["parameters"] || []
             parent_params.reject! do |v|
               v["in"] && keys.include?([v["in"].value, v["name"].value])
             end


### PR DESCRIPTION
This PR adds a support for APIs mounted under a path prefix by providing a new `path_prefix` option:

```ruby
# spec/rails_helper.rb

RSpec.configure do |config|
  # ...
  path_to_openapi = Rails.root.join("docs", "openapi.yml")
  # pass path_prefix option if your API is mounted under a prefix:
  config.include Skooma::RSpec[path_to_openapi, path_prefix: "/internal/api"], type: :request
end
```

In my tests, this approach turned out to be simpler than trying to guess the correct path using [`servers` keyword](https://spec.openapis.org/oas/v3.1.0#server-object) from #6 and #8.