### PR TITLE
Set `content` and `required` keyword dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `Skooma::Error: Missing name key /request` by setting `content` and `required` keyword dependencies. ([@skryukov])
+
 ## [0.2.2] - 2024-01-04
 
 ### Added

--- a/lib/skooma/objects/parameter/keywords/content.rb
+++ b/lib/skooma/objects/parameter/keywords/content.rb
@@ -8,6 +8,7 @@ module Skooma
           self.key = "content"
           self.value_schema = :object_of_schemas
           self.schema_value_class = Objects::MediaType
+          self.depends_on = %w[in name style explode allowReserved allowEmptyValue]
 
           def evaluate(instance, result)
             return if instance.value.nil?

--- a/lib/skooma/objects/parameter/keywords/required.rb
+++ b/lib/skooma/objects/parameter/keywords/required.rb
@@ -6,6 +6,7 @@ module Skooma
       module Keywords
         class Required < JSONSkooma::Keywords::Base
           self.key = "required"
+          self.depends_on = %w[in name style explode allowReserved allowEmptyValue]
 
           def evaluate(instance, result)
             if json.value && ValueParser.call(instance, result)&.value.nil?

--- a/lib/skooma/objects/parameter/keywords/value_parser.rb
+++ b/lib/skooma/objects/parameter/keywords/value_parser.rb
@@ -13,7 +13,7 @@ module Skooma
               raise Error, "Missing `in` key #{result.path}" unless type
 
               key = result.sibling(instance, "name")&.annotation
-              raise Error, "Missing `name` key #{instance.path}: #{key}" unless key
+              raise Error, "Missing `name` key #{result.path}" unless key
 
               case type
               when "query"

--- a/spec/openapi_test_suite/query_params.json
+++ b/spec/openapi_test_suite/query_params.json
@@ -13,8 +13,8 @@
             "parameters": [
               {
                 "in": "query",
-                "name": "foo",
                 "required": true,
+                "name": "foo",
                 "schema": {
                   "type": "string",
                   "minLength": 3
@@ -22,7 +22,7 @@
               },
               {
                 "in": "query",
-                "name": "bar",
+                "required": false,
                 "content": {
                   "application/json": {
                     "schema": {
@@ -30,7 +30,8 @@
                       "minLength": 3
                     }
                   }
-                }
+                },
+                "name": "bar"
               }
             ],
             "responses": {


### PR DESCRIPTION
This PR fixes `Skooma::Error: Missing name key /request` error by setting `content` and `required` keyword dependencies.

Closes #12