### PR TITLE
Pass headers to body parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING CHANGE: Pass `headers` parameter to registered `BodyParsers`. ([@skryukov])
+
+    ```ruby
+    # Before:
+    Skooma::BodyParsers.register("application/xml", ->(body) { Hash.from_xml(body) })
+    # After:
+    Skooma::BodyParsers.register("application/xml", ->(body, headers:) { Hash.from_xml(body) })
+    ```
+
 ## [0.2.3] - 2024-01-18
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
 
-gem "standard", "~> 1.3"
+gem "standard", "~> 1.35.0"

--- a/lib/skooma/body_parsers.rb
+++ b/lib/skooma/body_parsers.rb
@@ -3,7 +3,7 @@
 module Skooma
   module BodyParsers
     class << self
-      DEFAULT_PARSER = ->(body) { body }
+      DEFAULT_PARSER = ->(body, **_options) { body }
 
       def [](media_type)
         parsers[media_type.to_s.strip.downcase] || DEFAULT_PARSER
@@ -20,7 +20,7 @@ module Skooma
     self.parsers = {}
 
     module JSONParser
-      def self.call(body)
+      def self.call(body, **_options)
         JSON.parse(body)
       rescue JSON::ParserError
         body

--- a/lib/skooma/env_mapper.rb
+++ b/lib/skooma/env_mapper.rb
@@ -23,8 +23,17 @@ module Skooma
         {
           "query" => env["rack.request.query_string"] || env["QUERY_STRING"],
           "headers" => env.select { |k, _| k.start_with?("HTTP_") || PLAIN_HEADERS.include?(k) }.transform_keys { |k| k.sub(REGEXP_HTTP, "").split("_").map(&:capitalize).join("-") },
-          "body" => env["RAW_POST_DATA"]
+          "body" => env["RAW_POST_DATA"] || read_rack_input(env["rack.input"])
         }
+      end
+
+      def read_rack_input(input)
+        return nil unless input.respond_to?(:rewind)
+
+        input.rewind
+        raw_input = input.read
+        input.rewind
+        raw_input
       end
 
       def map_response(response)

--- a/lib/skooma/instance.rb
+++ b/lib/skooma/instance.rb
@@ -63,16 +63,16 @@ module Skooma
         data = {}
         data["status"] = JSONSkooma::JSONNode.new(value.fetch("status"), key: "status", parent: self)
         data["headers"] = Headers.new(value.fetch("headers", {}), key: "headers", parent: self)
-        body_value = parse_body(value["body"], data["headers"]&.[]("Content-Type"))
+        body_value = parse_body(value["body"], data["headers"])
         data["body"] = Attribute.new(body_value, key: "body", parent: self)
         ["object", data]
       end
 
-      def parse_body(body, content_type)
+      def parse_body(body, headers)
         return nil unless body
 
-        parser = BodyParsers[content_type&.split(";")&.first]
-        parser ? parser.call(body) : body
+        parser = BodyParsers[headers["Content-Type"]&.value&.split(";")&.first]
+        parser ? parser.call(body, headers: headers) : body
       end
     end
 
@@ -83,16 +83,16 @@ module Skooma
         data = {}
         data["query"] = Attribute.new(value.fetch("query", ""), key: "query", parent: self)
         data["headers"] = Headers.new(value.fetch("headers", {}), key: "headers", parent: self)
-        body_value = parse_body(value["body"], data["headers"]&.[]("Content-Type"))
+        body_value = parse_body(value["body"], data["headers"])
         data["body"] = Attribute.new(body_value, key: "body", parent: self)
         ["object", data]
       end
 
-      def parse_body(body, content_type)
+      def parse_body(body, headers)
         return nil unless body
 
-        parser = BodyParsers[content_type&.split(";")&.first]
-        parser ? parser.call(body) : body
+        parser = BodyParsers[headers["Content-Type"]&.value&.split(";")&.first]
+        parser ? parser.call(body, headers: headers) : body
       end
     end
 


### PR DESCRIPTION
This PR adds a breaking change to the body parsers interface in order to provide a fix to the issue #16:

```yml
# docs/openapi.yaml
#...

paths:
  /upload:
    post:
      summary: Example of Active Storage upload
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              required: [file]
              properties:
                file: {}

      responses:
        "200":
           description: successful operation
        "422":
           $ref: '#/components/responses/ErrorResponse'
```

```ruby
# spec/rails_helper.rb
#...

Skooma::BodyParsers.register("multipart/form-data", ->(body, headers:) do
    info = Rack::Multipart::Parser.parse(
      StringIO.new(body),
      headers["Content-Length"].to_i,
      headers["Content-Type"],
      ->(*) { String.new },
      Rack::Multipart::Parser::BUFSIZE,
      Rack::Utils.default_query_parser,
    )
    info.params
  end)
```

```ruby
# spec/requests/upload_spec.rb
# ...
  describe "POST /upload" do
    subject { post("/upload", params:) }

    let(:test_file) { file_fixture("image.jpeg") }
    let(:file) { fixture_file_upload(test_file, "image/jpeg") }

    let(:params) { {file:} }

    it { is_expected.to conform_schema(200) }

    context "without file" do
      let(:file) { nil }

      it { is_expected.to conform_response_schema(422) }
    end
  end
```