### PR TITLE
Updated example comment for Skooma::Minitest class

### DIFF
--- a/lib/skooma/minitest.rb
+++ b/lib/skooma/minitest.rb
@@ -6,7 +6,7 @@ module Skooma
   # Minitest helpers for OpenAPI schema validation
   # @example
   #   describe TestApp do
-  #     include Skooma::RSpec[Rails.root.join("docs", "openapi.yml")]
+  #     include Skooma::Minitest[Rails.root.join("docs", "openapi.yml")]
   #     # ...
   #   end
   class Minitest < Matchers::Wrapper

--- a/lib/skooma/version.rb
+++ b/lib/skooma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Skooma
-  VERSION = "0.3.3"
+  VERSION = "0.3.2"
 end

--- a/lib/skooma/version.rb
+++ b/lib/skooma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Skooma
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
While I investigate how `skooma` works I found the typo in `Skooma::Minitest` class.
In example was `include Skooma::RSpec[Rails.root.join("docs", "openapi.yml")]` but should be `include Skooma::Minitest[Rails.root.join("docs", "openapi.yml")]`.