### PR TITLE
Register "application/vnd.api+json" as media type

### DIFF
--- a/lib/skooma/body_parsers.rb
+++ b/lib/skooma/body_parsers.rb
@@ -27,5 +27,6 @@ module Skooma
       end
     end
     register "application/json", JSONParser
+    register "application/vnd.api+json", JSONParser
   end
 end

--- a/spec/openapi_test_suite/openapi_formats.json
+++ b/spec/openapi_test_suite/openapi_formats.json
@@ -41,6 +41,59 @@
               }
             }
           }
+        },
+        "/users": {
+          "get": {
+            "responses": {
+              "200": {
+                "description": "List of users",
+                "content": {
+                  "application/vnd.api+json": {
+                    "schema": {
+                      "type": "object",
+                      "required": ["data"],
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["type", "id", "attributes"],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": ["users"]
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "attributes": {
+                                "type": "object",
+                                "required": ["name", "email"],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "email": {
+                                    "type": "string",
+                                    "format": "email"
+                                  },
+                                  "age": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 120
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -104,6 +157,26 @@
           }
         },
         "valid": false
+      },
+      {
+        "description": "valid users response",
+        "data": {
+          "method": "get",
+          "path": "/users",
+          "request": {
+            "headers": {
+              "Content-Type": "application/vnd.api+json"
+            }
+          },
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/vnd.api+json"
+            },
+            "body": "{\"data\":[{\"type\":\"users\",\"id\":\"1\",\"attributes\":{\"name\":\"John Doe\",\"email\":\"john@example.com\",\"age\":30}},{\"type\":\"users\",\"id\":\"2\",\"attributes\":{\"name\":\"Jane Smith\",\"email\":\"jane@example.com\",\"age\":25}}]}"
+          }
+        },
+        "valid": true
       }
     ]
   }


### PR DESCRIPTION
Currently, there is no media type registered for the JSON:API specification. As a result, JSON:API responses are parsed using the default parser, which treats the response body as a string. When an OpenAPI specification with a JSON:API response expects an object, the matchers fail with the error "The instance must be of type object, but was string".

This change registers the JSON:API media type `application/vnd.api+json` and configures it to use the existing JSONParser to parse JSON:API responses.

