### PR TITLE
Initial support for `readOnly` & `writeOnly` keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Experimental support for `readOnly` and `writeOnly` keywords. ([@skryukov])
+
+    ```ruby
+    # spec/rails_helper.rb
+    
+    RSpec.configure do |config|
+      # To enable support for readOnly and writeOnly keywords, pass `enforce_access_modes: true` option:
+      config.include Skooma::RSpec[Rails.root.join("docs", "openapi.yml"), enforce_access_modes: true], type: :request
+    end
+    ```
+
 ## [0.3.3] - 2024-10-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ ActionDispatch::IntegrationTest.include Skooma::Minitest[path_to_openapi, path_p
 # To enable coverage, pass `coverage: :report` option,
 # and to raise an error when an operation is not covered, pass `coverage: :strict` option:
 ActionDispatch::IntegrationTest.include Skooma::Minitest[path_to_openapi, coverage: :report], type: :request
+
+# EXPERIMENTAL
+# To enable support for readOnly and writeOnly keywords, pass `enforce_access_modes: true` option:
+ActionDispatch::IntegrationTest.include Skooma::Minitest[path_to_openapi, enforce_access_modes: true], type: :request
 ```
 
 #### Validate OpenAPI document

--- a/lib/skooma/dialects/oas_3_1.rb
+++ b/lib/skooma/dialects/oas_3_1.rb
@@ -16,6 +16,9 @@ module Skooma
             Skooma::Keywords::OAS31::Dialect::OneOf,
             Skooma::Keywords::OAS31::Dialect::Discriminator,
             Skooma::Keywords::OAS31::Dialect::Xml,
+            Skooma::Keywords::OAS31::Dialect::Properties,
+            Skooma::Keywords::OAS31::Dialect::AdditionalProperties,
+            Skooma::Keywords::OAS31::Dialect::Required,
             Skooma::Keywords::OAS31::Dialect::ExternalDocs,
             Skooma::Keywords::OAS31::Dialect::Example
           )

--- a/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Skooma
+  module Keywords
+    module OAS31
+      module Dialect
+        class AdditionalProperties < JSONSkooma::Keywords::Applicator::AdditionalProperties
+          self.key = "additionalProperties"
+          self.instance_types = "object"
+          self.value_schema = :schema
+          self.depends_on = %w[properties patternProperties]
+
+          def evaluate(instance, result)
+            known_property_names = result.sibling(instance, "properties")&.schema_node&.keys || []
+            known_property_patterns = (result.sibling(instance, "patternProperties")&.schema_node&.keys || [])
+              .map { |pattern| Regexp.new(pattern) }
+
+            forbidden = []
+
+            if json.root.enforce_access_modes?
+              only_key = result.path.include?("responses") ? "writeOnly" : "readOnly"
+              properties_result = result.sibling(instance, "properties")
+              instance.each_key do |name|
+                res = properties_result&.children&.[](instance[name]&.path)&.[]name
+                forbidden << name.tap { puts "adding #{name}" } if annotation_exists?(res, key: only_key)
+              end
+            end
+
+            annotation = []
+            error = []
+
+            instance.each do |name, item|
+              if forbidden.include?(name) || !known_property_names.include?(name) && known_property_patterns.none? { |pattern| pattern.match?(name) }
+                if json.evaluate(item, result).passed?
+                  annotation << name
+                else
+                  error << name
+                  # reset to success for the next iteration
+                  result.success
+                end
+              end
+            end
+            return result.annotate(annotation) if error.empty?
+
+            result.failure(error)
+          end
+
+          private
+
+          def annotation_exists?(result, key:)
+            return result if result.key == key && result.annotation
+
+            result.each_children do |child|
+              return child if annotation_exists?(child, key: key)
+            end
+
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/skooma/keywords/oas_3_1/dialect/properties.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/properties.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Skooma
+  module Keywords
+    module OAS31
+      module Dialect
+        class Properties < JSONSkooma::Keywords::Applicator::Properties
+          self.key = "properties"
+          self.instance_types = "object"
+          self.value_schema = :object_of_schemas
+
+          def evaluate(instance, result)
+            annotation = []
+            err_names = []
+            instance.each do |name, item|
+              next unless json.value.key?(name)
+
+              result.call(item, name) do |subresult|
+                json[name].evaluate(item, subresult)
+                if ignored_with_only_key?(subresult)
+                  subresult.discard
+                elsif subresult.passed?
+                  annotation << name
+                else
+                  err_names << name
+                end
+              end
+            end
+
+            return result.annotate(annotation) if err_names.empty?
+
+            result.failure("Properties #{err_names.join(", ")} are invalid")
+          end
+
+          private
+
+          def ignored_with_only_key?(subresult)
+            return false unless json.root.enforce_access_modes?
+
+            if subresult.parent.path.include?("responses")
+              subresult.children["readOnly"]&.value == true
+            else
+              subresult.children["writeOnly"]&.value == true
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/skooma/keywords/oas_3_1/dialect/required.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/required.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Skooma
+  module Keywords
+    module OAS31
+      module Dialect
+        class Required < JSONSkooma::Keywords::Validation::Required
+          self.key = "required"
+          self.instance_types = "object"
+          self.depends_on = %w[properties]
+
+          def evaluate(instance, result)
+            missing = required_keys.reject { |key| instance.key?(key) }
+            return if missing.none?
+
+            if json.root.enforce_access_modes?
+              properties_schema = result.sibling(instance, "properties")&.schema_node || {}
+              only_key = result.path.include?("responses") ? "writeOnly" : "readOnly"
+              ignore = []
+              missing.each do |name|
+                next unless properties_schema.key?(name)
+
+                result.call(nil, name) do |subresult|
+                  properties_schema[name].evaluate(nil, subresult)
+                  ignore << name if annotation_exists?(subresult, key: only_key)
+                  subresult.discard
+                end
+              end
+
+              return if (missing - ignore).none?
+            end
+
+            result.failure(missing_keys_message(missing))
+          end
+
+          private
+
+          def annotation_exists?(result, key:)
+            return result if result.key == key && result.annotation
+
+            result.each_children do |child|
+              return child if annotation_exists?(child, key: key)
+            end
+
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/skooma/matchers/wrapper.rb
+++ b/lib/skooma/matchers/wrapper.rb
@@ -44,7 +44,7 @@ module Skooma
         end
       end
 
-      def initialize(helper_methods_module, openapi_path, base_uri: "https://skoomarb.dev/", path_prefix: "", **params)
+      def initialize(helper_methods_module, openapi_path, base_uri: "https://skoomarb.dev/", path_prefix: "", enforce_access_modes: false, **params)
         super()
 
         registry = create_test_registry
@@ -57,6 +57,7 @@ module Skooma
         )
         @schema = registry.schema(URI.parse("#{source_uri}#{pathname.basename}"), schema_class: Skooma::Objects::OpenAPI)
         @schema.path_prefix = path_prefix
+        @schema.enforce_access_modes = enforce_access_modes
 
         @coverage = Coverage.new(@schema, mode: params[:coverage], format: params[:coverage_format])
 

--- a/lib/skooma/objects/openapi.rb
+++ b/lib/skooma/objects/openapi.rb
@@ -39,6 +39,16 @@ module Skooma
         @path_prefix = @path_prefix.delete_suffix("/") if @path_prefix.end_with?("/")
       end
 
+      def enforce_access_modes=(value)
+        raise ArgumentError, "Enforce access modes must be a boolean" unless [true, false].include?(value)
+
+        @enforce_access_modes = value
+      end
+
+      def enforce_access_modes?
+        @enforce_access_modes
+      end
+
       def path_prefix
         @path_prefix || ""
       end

--- a/spec/openapi_test_suite/read_write_only.json
+++ b/spec/openapi_test_suite/read_write_only.json
@@ -1,0 +1,239 @@
+[
+  {
+    "description": "ReadOnly and WriteOnly Properties Ignored by Default Test Suite",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "post": {
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "201": {
+                "description": "Created",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Id": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "User": {
+            "type": "object",
+            "required": [
+              "id",
+              "name",
+              "password"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/Id"
+              },
+              "name": {
+                "type": "string"
+              },
+              "password": {
+                "type": "string",
+                "writeOnly": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "readOnly and writeOnly are ignored",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "request with invalid response body",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": \"1\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "request with invalid request body",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": 1}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "request with readOnly property in request body",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "response with writeOnly property",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\", \"password\": \"secret\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "missing required password in request",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "missing required id in response",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "wrong id type in response",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": \"abc\", \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/with_enforce_access_modes/read_write_only.json
+++ b/spec/openapi_test_suite/with_enforce_access_modes/read_write_only.json
@@ -1,0 +1,239 @@
+[
+  {
+    "description": "ReadOnly and WriteOnly Properties With enforce_access_modes attribute Test Suite",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "post": {
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "201": {
+                "description": "Created",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Id": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "User": {
+            "type": "object",
+            "required": [
+              "id",
+              "name",
+              "password"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/Id"
+              },
+              "name": {
+                "type": "string"
+              },
+              "password": {
+                "type": "string",
+                "writeOnly": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid request",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "request with invalid response body",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": \"1\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "request with invalid request body",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": 1}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "request with readOnly property in request body",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "response with writeOnly property",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\", \"password\": \"secret\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "missing required password in request",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "missing required id in response",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "wrong id type in response",
+        "data": {
+          "method": "post",
+          "path": "/",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"John Doe\", \"password\": \"secret\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": \"abc\", \"name\": \"John Doe\"}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/skooma_spec.rb
+++ b/spec/skooma_spec.rb
@@ -1,41 +1,66 @@
 # frozen_string_literal: true
 
+CONFIGS = {
+  default: proc {},
+  with_enforce_access_modes: ->(schema) do
+    schema.enforce_access_modes = true
+  end
+}.freeze
+
 RSpec.describe Skooma do
   before(:all) { Skooma.create_registry }
 
-  Dir["#{File.expand_path("../openapi_test_suite", __FILE__)}/*.json"].each do |file|
-    JSON.parse(File.read(file)).each do |test_case|
-      context test_case["description"] do
-        let(:schema) do
-          Skooma::Objects::OpenAPI.new(test_case["schema"])
-        end
+  CONFIGS.each do |config_name, config_applier|
+    context "with #{config_name} configuration" do
+      spec_dir = File.expand_path("openapi_test_suite", __dir__)
+      config_dir = File.join(spec_dir, config_name.to_s) if config_name != :default
 
-        it "contains a valid openapi schema" do
-          result = schema.validate
-          expect(result).to be_valid, <<~MSG
-            Expected given schema to be valid.
+      base_files = Dir["#{spec_dir}/*.json"].map { |f| [File.basename(f), f] }.to_h
+      config_files = if config_dir && Dir.exist?(config_dir)
+        Dir["#{config_dir}/*.json"].map { |f| [File.basename(f), f] }.to_h
+      else
+        {}
+      end
 
-            Schema:
-            #{JSON.pretty_generate(test_case["schema"])}
+      test_files = base_files.merge(config_files)
 
-            Validation output:
-            #{JSON.pretty_generate(result.output(:detailed))}
-          MSG
-        end
+      test_files.values.each do |file|
+        JSON.parse(File.read(file)).each do |test_case|
+          context test_case["description"] do
+            let(:schema) do
+              Skooma::Objects::OpenAPI.new(test_case["schema"]).tap do |schema|
+                config_applier.call(schema)
+              end
+            end
 
-        test_case["tests"].each do |test|
-          it test["description"] do
-            result = schema.evaluate(test["data"])
+            it "contains a valid openapi schema" do
+              result = schema.validate
+              expect(result).to be_valid, <<~MSG
+                Expected given schema to be valid.
 
-            expect(result.valid?).to eq(test["valid"]), <<~MSG
-              Expected given response to be #{test["valid"] ? "valid" : "invalid"}.
-              
-              Response:
-              #{JSON.pretty_generate(test["data"])}
+                Schema:
+                #{JSON.pretty_generate(test_case["schema"])}
 
-              Validation output:
-              #{JSON.pretty_generate(result.output(:detailed))}
-            MSG
+                Validation output:
+                #{JSON.pretty_generate(result.output(:detailed))}
+              MSG
+            end
+
+            test_case["tests"].each do |test|
+              it test["description"] do
+                result = schema.evaluate(test["data"])
+
+                expect(result.valid?).to eq(test["valid"]), <<~MSG
+                  Expected given response to be #{test["valid"] ? "valid" : "invalid"}.
+
+                  Response:
+                  #{JSON.pretty_generate(test["data"])}
+
+                  Validation output:
+                  #{JSON.pretty_generate(result.output(:detailed))}
+                MSG
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
This PR adds support for `readOnly` & `writeOnly` keywords in context of `properties`, `required` and `additionalProperties` keywords.

This allows using schemas like this in both request and response bodies:

```yaml
components:
  schemas:
    Id:
      type: integer
      format: int64
      readOnly: true

    User:
      type: object
      required: [id, name, password]
      additionalProperties: false
      properties:
        id:
          $ref: "#/components/schemas/Id"
        name:
          type: string
        password:
          type: string
          writeOnly: true
```

Closes #35