### PR TITLE
Fix enforce access mode with additional properties

### DIFF
--- a/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb
@@ -22,7 +22,7 @@ module Skooma
               properties_result = result.sibling(instance, "properties")
               instance.each_key do |name|
                 res = properties_result&.children&.[](instance[name]&.path)&.[]name
-                forbidden << name.tap { puts "adding #{name}" } if annotation_exists?(res, key: only_key)
+                forbidden << name.tap { puts "adding #{name}" } if res && annotation_exists?(res, key: only_key)
               end
             end
 

--- a/spec/openapi_test_suite/with_enforce_access_modes/read_write_only.json
+++ b/spec/openapi_test_suite/with_enforce_access_modes/read_write_only.json
@@ -48,7 +48,12 @@
               "name",
               "password"
             ],
-            "additionalProperties": false,
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "properties": {
               "id": {
                 "$ref": "#/components/schemas/Id"
@@ -82,7 +87,7 @@
             "headers": {
               "Content-Type": "application/json"
             },
-            "body": "{\"id\": 1, \"name\": \"John Doe\"}"
+            "body": "{\"id\": 1, \"name\": \"John Doe\", \"extra\": [\"test\"]}"
           }
         },
         "valid": true


### PR DESCRIPTION
I came across an error when testing out `enforce_access_modes`. When `additionalProperties` is configured, it seems to look up that property in the main properties list but then fail if it can't be found. This is the exception:

```
    NoMethodError:
       undefined method 'key' for nil
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/skooma-0.3.4/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb:52:in 'Skooma::Keywords::OAS31::Dialect::AdditionalProperties#annotation_exists?'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/skooma-0.3.4/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb:26:in 'block in Skooma::Keywords::OAS31::Dialect::AdditionalProperties#evaluate'
     # /ruby/3.4.3/lib/ruby/3.4.0/delegate.rb:87:in 'Hash#each_key'
     # /ruby/3.4.3/lib/ruby/3.4.0/delegate.rb:87:in 'Delegator#method_missing'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/skooma-0.3.4/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb:23:in 'Skooma::Keywords::OAS31::Dialect::AdditionalProperties#evaluate'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/json_schema.rb:41:in 'block (2 levels) in JSONSkooma::JSONSchema#evaluate'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/result.rb:65:in 'JSONSkooma::Result#call'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/json_schema.rb:40:in 'block in JSONSkooma::JSONSchema#evaluate'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/json_schema.rb:37:in 'Hash#each'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/json_schema.rb:37:in 'JSONSkooma::JSONSchema#evaluate'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/keywords/core/ref.rb:14:in 'JSONSkooma::Keywords::Core::Ref#evaluate'
     # /ruby/3.4.3/lib/ruby/gems/3.4.0/gems/json_skooma-0.2.5/lib/json_skooma/json_schema.rb:41:in 'block (2 levels) in JSONSkooma::JSONSchema#evaluate'```