### PR TITLE
Fix examples and callbacks support in Components

### DIFF
--- a/lib/skooma/objects/components.rb
+++ b/lib/skooma/objects/components.rb
@@ -9,12 +9,12 @@ module Skooma
         "schemas" => JSONSkooma::JSONSchema,
         "responses" => Response,
         "parameters" => Parameter,
-        # "examples" => Example,
+        "examples" => JSONSkooma::JSONNode,
         "requestBodies" => RequestBody,
         "headers" => Header,
         "securitySchemes" => JSONSkooma::JSONNode,
         "links" => JSONSkooma::JSONNode,
-        # "callbacks" => Callback,
+        "callbacks" => JSONSkooma::JSONNode,
         "pathItems" => PathItem
       }
 

--- a/spec/openapi_test_suite/examples_and_callbacks.json
+++ b/spec/openapi_test_suite/examples_and_callbacks.json
@@ -1,0 +1,136 @@
+[
+  {
+    "description": "Components with examples and callbacks",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "API with examples and callbacks",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/users": {
+          "post": {
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/User"
+                  },
+                  "examples": {
+                    "default": {
+                      "$ref": "#/components/examples/user"
+                    }
+                  }
+                }
+              }
+            },
+            "responses": {
+              "201": {
+                "description": "Created",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            },
+            "callbacks": {
+              "statusUpdate": {
+                "$ref": "#/components/callbacks/statusUpdate"
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "User": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            },
+            "required": [
+              "name",
+              "email"
+            ]
+          }
+        },
+        "examples": {
+          "user": {
+            "value": {
+              "id": 1,
+              "name": "John Doe",
+              "email": "john@example.com"
+            },
+            "summary": "A sample user"
+          }
+        },
+        "callbacks": {
+          "statusUpdate": {
+            "{$request.body#/callbackUrl}": {
+              "post": {
+                "requestBody": {
+                  "required": true,
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "Notification received"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "schema that uses $ref to examples and callbacks",
+        "data": {
+          "method": "post",
+          "path": "/users",
+          "request": {
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"name\": \"Jane Smith\", \"email\": \"jane@example.com\"}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": "{\"id\": 2, \"name\": \"Jane Smith\", \"email\": \"jane@example.com\"}"
+          }
+        },
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Previously, OpenAPI schemas with `components.examples` or `components.callbacks` would raise a `KeyError`. This adds support for these component types by mapping them to `JSONSkooma::JSONNode`.