### PR TITLE
Add support for symbolic response codes

### DIFF
--- a/lib/skooma/env_mapper.rb
+++ b/lib/skooma/env_mapper.rb
@@ -40,6 +40,7 @@ module Skooma
         status, headers, body = response.to_a
         full_body = +""
         body.each { |chunk| full_body << chunk }
+
         {
           "status" => status,
           "headers" => headers.to_h,

--- a/lib/skooma/matchers/conform_response_schema.rb
+++ b/lib/skooma/matchers/conform_response_schema.rb
@@ -5,7 +5,17 @@ module Skooma
     class ConformResponseSchema < ConformRequestSchema
       def initialize(skooma, mapped_response, expected)
         super(skooma, mapped_response)
+
         @expected = expected
+
+        case expected
+        when Symbol
+          @expected_code = Rack::Utils::SYMBOL_TO_STATUS_CODE.fetch(expected)
+        when Integer
+          @expected_code = expected
+        else
+          raise ArgumentError, "Expected symbol or number, got expected=#{expected.inspect}"
+        end
       end
 
       def description


### PR DESCRIPTION
This aims to add support for symbolic codes in expectations, supporting the following:

```ruby
expect(response).to conform_schema(:ok)
```