### PR TITLE
Minitest 6 compatibility

### DIFF
--- a/lib/skooma/minitest.rb
+++ b/lib/skooma/minitest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "minitest/unit"
+require "minitest"
 
 module Skooma
   # Minitest helpers for OpenAPI schema validation


### PR DESCRIPTION
After upgrading to Minitest 6, which seems to have [removed](https://rubytalk.org/t/ruby-talk-444727-ann-minitest-6-0-0-released/76683) `minitest/unit` I got:

```txt
> rails t
/Users/visini/.rbenv/versions/4.0.0/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- minitest/unit (LoadError)
        from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
        from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/gems/bootsnap-1.20.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in 'Kernel#require'
        from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/gems/zeitwerk-2.7.4/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
        from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/bundler/gems/skooma-cc454ee4d9fe/lib/skooma/minitest.rb:3:in '<main>'
        from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
        from /Users/visini/.rbenv/versions/4.0.0/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
        # ...
```

I'm not sure if this change breaks skooma for people on Minitest 5, but after downgrading Minitest `gem "minitest", ">= 5", "< 6"` it seems to work and tests pass.