### PR TITLE
Fix annotation_exists? bubbling readOnly/writeOnly from nested $refs

### DIFF
--- a/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb
+++ b/lib/skooma/keywords/oas_3_1/dialect/additional_properties.rb
@@ -22,7 +22,7 @@ module Skooma
               properties_result = result.sibling(instance, "properties")
               instance.each_key do |name|
                 res = properties_result&.children&.[](instance[name]&.path)&.[]name
-                forbidden << name.tap { puts "adding #{name}" } if res && annotation_exists?(res, key: only_key)
+                forbidden << name if res && annotation_exists?(res, key: only_key)
               end
             end
 
@@ -50,7 +50,7 @@ module Skooma
           def annotation_exists?(result, key:)
             return result if result.key == key && result.annotation
 
-            result.each_children do |child|
+            result.children[result.instance.path]&.each_value do |child|
               return child if annotation_exists?(child, key: key)
             end
 

--- a/spec/openapi_test_suite/with_enforce_access_modes/nested_ref_read_write_only.json
+++ b/spec/openapi_test_suite/with_enforce_access_modes/nested_ref_read_write_only.json
@@ -1,0 +1,106 @@
+[
+  {
+    "description": "Nested ref schemas do not bubble readOnly/writeOnly up to enclosing additionalProperties",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/orders": {
+          "post": {
+            "requestBody": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["order"],
+                    "properties": {
+                      "order": {"$ref": "#/components/schemas/Order"}
+                    }
+                  }
+                }
+              }
+            },
+            "responses": {
+              "201": {
+                "description": "Created",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["order"],
+                      "properties": {
+                        "order": {"$ref": "#/components/schemas/Order"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Order": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "readOnly": true
+              },
+              "name": {
+                "type": "string"
+              },
+              "secret": {
+                "type": "string",
+                "writeOnly": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "request with nested readOnly field does not falsely flag the wrapping property as additionalProperty",
+        "data": {
+          "method": "post",
+          "path": "/orders",
+          "request": {
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"order\": {\"id\": 1, \"name\": \"Widget\"}}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"order\": {\"id\": 1, \"name\": \"Widget\"}}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "response with nested writeOnly field does not falsely flag the wrapping property as additionalProperty",
+        "data": {
+          "method": "post",
+          "path": "/orders",
+          "request": {
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"order\": {\"name\": \"Widget\", \"secret\": \"shh\"}}"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"order\": {\"id\": 1, \"name\": \"Widget\", \"secret\": \"shh\"}}"
+          }
+        },
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

`annotation_exists?` in `additional_properties.rb` recursed through the entire result subtree of a property's evaluation. When a property's schema is a `$ref` to an object that contains `readOnly`/`writeOnly` fields, the recursion found those grandchild annotations and marked the **wrapping** property as forbidden. With `additionalProperties: false` on the enclosing schema, the wrapping property was then rejected with a spurious additionalProperties error.

This PR bounds the recursion to children at the same `instance.path`. `$ref` / `allOf` / `anyOf` evaluate the same instance so they're still traversed; `properties` / `items` create children at deeper instance paths and are now correctly skipped.

Also drops a leftover `puts "adding #{name}"` debug call from #f945060.

### Repro (before the fix)

```ruby
# request body schema: { properties: { order: { $ref: '#/components/schemas/Order' } }, additionalProperties: false }
# Order schema:        { properties: { id: { readOnly: true }, name: { type: string } } }
# request body:        {"order": {"id": 1, "name": "Widget"}}
```

Validation output before:

```
"keywordLocation": ".../additionalProperties",
"error": ["order"]
```

The error should be about the inner `id`, not the outer `order`.

## Test plan

- [x] New JSON fixture at `spec/openapi_test_suite/with_enforce_access_modes/nested_ref_read_write_only.json` covering both request-side `readOnly` and response-side `writeOnly` nested under a `$ref`. These tests fail on `main` (the wrapping `order` shows up in the `additionalProperties` error array) and pass after the fix.
- [x] Full `bundle exec rspec` is green (232 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)