### PR TITLE
Fix ConformResponseSchema#status_matches? for symbolic status codes

### DIFF
--- a/lib/skooma/matchers/conform_response_schema.rb
+++ b/lib/skooma/matchers/conform_response_schema.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rack/utils"
+
 module Skooma
   module Matchers
     class ConformResponseSchema < ConformRequestSchema
@@ -37,7 +39,7 @@ module Skooma
       private
 
       def status_matches?
-        @mapped_response["response"]["status"] == @expected
+        @mapped_response["response"]["status"] == @expected_code
       end
     end
   end

--- a/skooma.gemspec
+++ b/skooma.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + Dir.glob("data/**/*") + %w[README.md LICENSE.txt CHANGELOG.md]
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "rack", ">= 2.0"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
   spec.add_runtime_dependency "json_skooma", "~> 0.2.5"
 end

--- a/spec/skooma/matchers/conform_response_schema_spec.rb
+++ b/spec/skooma/matchers/conform_response_schema_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Skooma::Matchers::ConformResponseSchema do
+  let(:result) { instance_double(JSONSkooma::Result, valid?: true) }
+  let(:schema) { instance_double(Skooma::Objects::OpenAPI, evaluate: result) }
+  let(:coverage) { instance_double(Skooma::Coverage, track_request: nil) }
+  let(:skooma) { instance_double(Skooma::Matchers::Wrapper, schema: schema, coverage: coverage) }
+  let(:mapped_response) { {"response" => {"status" => 201}} }
+
+  subject(:matcher) { described_class.new(skooma, mapped_response, expected) }
+
+  describe "#matches?" do
+    context "with an integer matching the response status" do
+      let(:expected) { 201 }
+
+      it { expect(matcher.matches?).to be true }
+    end
+
+    context "with an integer not matching the response status" do
+      let(:expected) { 200 }
+
+      it { expect(matcher.matches?).to be false }
+    end
+
+    context "with a symbol matching the response status" do
+      let(:expected) { :created }
+
+      it { expect(matcher.matches?).to be true }
+    end
+
+    context "with a symbol not matching the response status" do
+      let(:expected) { :ok }
+
+      it { expect(matcher.matches?).to be false }
+    end
+
+    context "when the status matches but the schema validation fails" do
+      let(:expected) { 201 }
+      let(:result) { instance_double(JSONSkooma::Result, valid?: false) }
+
+      it { expect(matcher.matches?).to be false }
+    end
+  end
+
+  describe "#initialize" do
+    context "with neither a symbol nor an integer" do
+      let(:expected) { "201" }
+
+      it "raises ArgumentError" do
+        expect { matcher }.to raise_error(ArgumentError, /Expected symbol or number/)
+      end
+    end
+
+    context "with an unknown symbol" do
+      let(:expected) { :nonsense }
+
+      it "raises KeyError" do
+        expect { matcher }.to raise_error(KeyError)
+      end
+    end
+  end
+
+  describe "#failure_message" do
+    let(:expected) { :ok }
+
+    it "renders the supplied expected value" do
+      matcher.matches?
+      expect(matcher.failure_message).to eq("Expected ok status code, but got 201")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`ConformResponseSchema#status_matches?` (`lib/skooma/matchers/conform_response_schema.rb`) compares against `@expected` — the user-supplied value — instead of the converted `@expected_code` Integer. When a Symbol is passed (e.g. `is_expected.to conform_response_schema(:created)`), the comparison is always `201 == :created` and silently fails. Bug introduced alongside Symbol support in #50.

While verifying the fix I also hit two latent issues from #50:

1. `Rack::Utils::SYMBOL_TO_STATUS_CODE` is referenced without `require \"rack/utils\"`, so the Symbol path crashes with `NameError: uninitialized constant Rack` in any context where Rack hasn't been transitively loaded (Rails / rack-test load it for you, but pure RSpec doesn't).
2. `rack` is not declared as a runtime dependency in `skooma.gemspec`, even though the matcher uses it.

This PR addresses all three.

### Repro (before this PR)

```ruby
RSpec.describe \"POST /orders\" do
  subject { post(\"/orders\", params: {...}, as: :json) }
  it { is_expected.to conform_response_schema(:created) }  # always fails
end
```

Failure output prints `Expected created status code, but got 201` even though `201 == :created` semantically should match.

## Changes

- `lib/skooma/matchers/conform_response_schema.rb`
  - Compare against `@expected_code` in `#status_matches?`.
  - `require \"rack/utils\"` at the top so the constant lookup doesn't depend on transitive loading.
- `skooma.gemspec`
  - `add_runtime_dependency \"rack\", \">= 2.0\"` — open upper bound so Rails 7 / Rack 3 users aren't pinned.
- `spec/skooma/matchers/conform_response_schema_spec.rb` (new)
  - `#matches?`: Integer match/mismatch + Symbol match/mismatch + the short-circuit case where status matches but schema validation fails.
  - `#initialize`: non-Symbol/non-Integer raises `ArgumentError`; unknown Symbol raises `KeyError` (from `SYMBOL_TO_STATUS_CODE.fetch`).
  - `#failure_message` renders the original `@expected` (so `:ok` stays as `:ok`, not the resolved 200).

## Test plan

- [x] `bundle exec rspec spec/skooma/matchers/conform_response_schema_spec.rb` — 8 examples, 0 failures.
- [x] Reverting only the `@expected_code` line on a separate branch makes \"with a symbol matching the response status\" fail with `expected true / got false`, confirming the regression is caught.
- [x] Full `bundle exec rspec` — 235 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)