### PR TITLE
Add support for external $refs in OpenAPI documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Support for external `$ref`s in OpenAPI documents. References like `$ref: './responses.yaml#/UsersResponse'` now resolve against the spec file's directory (or any source registered on the registry) and are wrapped with the appropriate OpenAPI object type — Response, Parameter, Header, RequestBody, PathItem, or a plain JSON Schema for `schema:` refs. Chained and self-recursive external refs are supported. ([@skryukov])
+
+### Changed
+
+- Bumped minimum `json_skooma` to `~> 0.2.7` for the new typed `UnexpectedSchemaClassError` and public `Registry#load_json` (0.2.6 was yanked due to a packaging issue). ([@skryukov])
+
 ## [0.3.8] - 2026-04-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -176,6 +176,34 @@ class ItemsTest < ActionDispatch::IntegrationTest
 end
 ```
 
+### Splitting specs across files
+
+Skooma resolves external `$ref`s relative to the OpenAPI document's directory, so you can split a large spec into multiple files:
+
+```yaml
+# docs/openapi.yaml
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          $ref: './responses.yaml#/UsersResponse'
+  /health:
+    $ref: './paths.yaml#/Health'
+```
+
+References are wrapped with the appropriate OpenAPI object type based on context — `$ref` inside `responses` loads as a Response, inside `parameters` as a Parameter, inside `schema` as a JSON Schema, and so on. Chained (A → B → C) and self-recursive schemas work out of the box.
+
+Only local files are resolved by default. To load refs from other sources (e.g. HTTP), register a source on the registry:
+
+```ruby
+schema = Skooma::Minitest[path_to_openapi].schema
+schema.registry.add_source(
+  "https://example.com/schemas/",
+  JSONSkooma::Sources::Remote.new("https://example.com/schemas/")
+)
+```
+
 ## Alternatives
 
 - [openapi_first](https://github.com/ahx/openapi_first)
@@ -183,7 +211,6 @@ end
 
 ## Feature plans
 
-- Full support for external `$ref`s
 - Full OpenAPI 3.1.0 support:
   - respect `style` and `explode` keywords
   - xml

--- a/lib/skooma.rb
+++ b/lib/skooma.rb
@@ -22,6 +22,7 @@ module Skooma
 
   JSONSkooma.register_dialect("oas-3.1", Dialects::OAS31)
   JSONSkooma::Formatters.register :skooma, OutputFormat
+  JSONSkooma::Keywords::ValueSchemas.default_schema_class = Objects::Schema
 
   class << self
     def create_registry(name: REGISTRY_NAME)

--- a/lib/skooma/external_refs.rb
+++ b/lib/skooma/external_refs.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Skooma
+  # External $ref resolution: upstream treats a referenced document as a single
+  # JSONSchema and errors out when the fragment points at a non-schema node
+  # inside a raw map (e.g. `responses.yaml#/Users`). Here we load the raw
+  # document, navigate to the fragment, and wrap the subtree as the referrer's
+  # own class so OpenAPI semantics are preserved.
+  module ExternalRefs
+    def resolve_ref(uri)
+      super
+    rescue JSONSkooma::UnexpectedSchemaClassError
+      load_external_ref(resolve_uri(uri))
+    end
+
+    private
+
+    def load_external_ref(resolved_uri)
+      base_uri = resolved_uri.dup.tap { |u| u.fragment = nil }
+      raw_doc = registry.load_json(base_uri)
+
+      data =
+        if resolved_uri.fragment.nil? || resolved_uri.fragment.empty?
+          raw_doc
+        else
+          JSONSkooma::JSONPointer.new(resolved_uri.fragment).eval(raw_doc)
+        end
+
+      raise JSONSkooma::RegistryError, "Could not resolve $ref #{resolved_uri}" if data.nil?
+
+      wrap_external_data(data, resolved_uri)
+    end
+
+    def wrap_external_data(data, uri)
+      wrapped = self.class.new(
+        data,
+        parent: root,
+        registry: registry,
+        cache_id: cache_id,
+        uri: uri,
+        metaschema_uri: metaschema_uri
+      )
+      wrapped.resolve_references
+      wrapped
+    end
+  end
+end

--- a/lib/skooma/keywords/oas_3_1/schema.rb
+++ b/lib/skooma/keywords/oas_3_1/schema.rb
@@ -17,7 +17,7 @@ module Skooma
         private
 
         def wrap_value(value)
-          JSONSkooma::JSONSchema.new(
+          Objects::Schema.new(
             value,
             key: key,
             parent: parent_schema,

--- a/lib/skooma/objects/base.rb
+++ b/lib/skooma/objects/base.rb
@@ -3,6 +3,8 @@
 module Skooma
   module Objects
     class Base < JSONSkooma::JSONSchema
+      include ExternalRefs
+
       DEFAULT_OPTIONS = {
         registry: REGISTRY_NAME
       }.freeze

--- a/lib/skooma/objects/schema.rb
+++ b/lib/skooma/objects/schema.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Skooma
+  module Objects
+    # JSON Schema value inside an OpenAPI `schema:` keyword. Subclass of
+    # JSONSkooma::JSONSchema that participates in external $ref resolution.
+    class Schema < JSONSkooma::JSONSchema
+      include ExternalRefs
+    end
+  end
+end

--- a/skooma.gemspec
+++ b/skooma.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rack", ">= 2.0"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
-  spec.add_runtime_dependency "json_skooma", "~> 0.2.5"
+  spec.add_runtime_dependency "json_skooma", "~> 0.2.7"
 end

--- a/spec/openapi_test_suite/external_refs/basic/openapi.yaml
+++ b/spec/openapi_test_suite/external_refs/basic/openapi.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+info:
+  title: External refs — basic
+  version: "1.0"
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          $ref: './responses.yaml#/UsersResponse'
+  /users/{id}:
+    get:
+      parameters:
+        - $ref: './parameters.yaml#/UserId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './schemas.yaml#/User'

--- a/spec/openapi_test_suite/external_refs/basic/parameters.yaml
+++ b/spec/openapi_test_suite/external_refs/basic/parameters.yaml
@@ -1,0 +1,6 @@
+UserId:
+  name: id
+  in: path
+  required: true
+  schema:
+    type: integer

--- a/spec/openapi_test_suite/external_refs/basic/responses.yaml
+++ b/spec/openapi_test_suite/external_refs/basic/responses.yaml
@@ -1,0 +1,8 @@
+UsersResponse:
+  description: A list of users
+  content:
+    application/json:
+      schema:
+        type: array
+        items:
+          $ref: './schemas.yaml#/User'

--- a/spec/openapi_test_suite/external_refs/basic/schemas.yaml
+++ b/spec/openapi_test_suite/external_refs/basic/schemas.yaml
@@ -1,0 +1,9 @@
+User:
+  type: object
+  unevaluatedProperties: false
+  properties:
+    id:
+      type: integer
+    name:
+      type: string
+  required: [id, name]

--- a/spec/openapi_test_suite/external_refs/basic/tests.json
+++ b/spec/openapi_test_suite/external_refs/basic/tests.json
@@ -1,0 +1,68 @@
+[
+  {
+    "description": "external $ref to a Response (chained via schemas)",
+    "tests": [
+      {
+        "description": "GET /users with valid list",
+        "data": {
+          "method": "get",
+          "path": "/users",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "[{\"id\": 1, \"name\": \"Alice\"}]"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "GET /users with user missing name is invalid",
+        "data": {
+          "method": "get",
+          "path": "/users",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "[{\"id\": 1}]"
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "external $ref to a Parameter and a Schema",
+    "tests": [
+      {
+        "description": "GET /users/{id} with valid body",
+        "data": {
+          "method": "get",
+          "path": "/users/42",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"id\": 42, \"name\": \"Alice\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "GET /users/{id} with wrong-typed id",
+        "data": {
+          "method": "get",
+          "path": "/users/not-a-number",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"id\": 42, \"name\": \"Alice\"}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/external_refs/header/headers.yaml
+++ b/spec/openapi_test_suite/external_refs/header/headers.yaml
@@ -1,0 +1,6 @@
+RequestId:
+  description: Unique request identifier.
+  required: true
+  schema:
+    type: string
+    pattern: "^[0-9a-f-]+$"

--- a/spec/openapi_test_suite/external_refs/header/openapi.yaml
+++ b/spec/openapi_test_suite/external_refs/header/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: External Header refs
+  version: "1.0"
+paths:
+  /ping:
+    get:
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Request-Id:
+              $ref: './headers.yaml#/RequestId'
+          content:
+            application/json:
+              schema:
+                type: object

--- a/spec/openapi_test_suite/external_refs/header/tests.json
+++ b/spec/openapi_test_suite/external_refs/header/tests.json
@@ -1,0 +1,35 @@
+[
+  {
+    "description": "external $ref to a Header",
+    "tests": [
+      {
+        "description": "valid X-Request-Id header passes",
+        "data": {
+          "method": "get",
+          "path": "/ping",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json", "X-Request-Id": "abc-123-def"},
+            "body": "{}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "missing required X-Request-Id header fails",
+        "data": {
+          "method": "get",
+          "path": "/ping",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/external_refs/path_item/openapi.yaml
+++ b/spec/openapi_test_suite/external_refs/path_item/openapi.yaml
@@ -1,0 +1,7 @@
+openapi: 3.1.0
+info:
+  title: External PathItem refs
+  version: "1.0"
+paths:
+  /health:
+    $ref: './paths.yaml#/Health'

--- a/spec/openapi_test_suite/external_refs/path_item/paths.yaml
+++ b/spec/openapi_test_suite/external_refs/path_item/paths.yaml
@@ -1,0 +1,15 @@
+Health:
+  get:
+    responses:
+      '200':
+        description: Service is up
+        content:
+          application/json:
+            schema:
+              type: object
+              unevaluatedProperties: false
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [ok]

--- a/spec/openapi_test_suite/external_refs/path_item/tests.json
+++ b/spec/openapi_test_suite/external_refs/path_item/tests.json
@@ -1,0 +1,35 @@
+[
+  {
+    "description": "external $ref to a PathItem",
+    "tests": [
+      {
+        "description": "valid response passes",
+        "data": {
+          "method": "get",
+          "path": "/health",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"status\": \"ok\"}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "status not in enum fails",
+        "data": {
+          "method": "get",
+          "path": "/health",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"status\": \"broken\"}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/external_refs/recursive/openapi.yaml
+++ b/spec/openapi_test_suite/external_refs/recursive/openapi.yaml
@@ -1,0 +1,14 @@
+openapi: 3.1.0
+info:
+  title: Recursive external schema
+  version: "1.0"
+paths:
+  /tree:
+    get:
+      responses:
+        '200':
+          description: A tree
+          content:
+            application/json:
+              schema:
+                $ref: './schemas.yaml#/TreeNode'

--- a/spec/openapi_test_suite/external_refs/recursive/schemas.yaml
+++ b/spec/openapi_test_suite/external_refs/recursive/schemas.yaml
@@ -1,0 +1,11 @@
+TreeNode:
+  type: object
+  unevaluatedProperties: false
+  required: [name]
+  properties:
+    name:
+      type: string
+    children:
+      type: array
+      items:
+        $ref: './schemas.yaml#/TreeNode'

--- a/spec/openapi_test_suite/external_refs/recursive/tests.json
+++ b/spec/openapi_test_suite/external_refs/recursive/tests.json
@@ -1,0 +1,49 @@
+[
+  {
+    "description": "self-referential external schema",
+    "tests": [
+      {
+        "description": "valid leaf node",
+        "data": {
+          "method": "get",
+          "path": "/tree",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"name\": \"root\", \"children\": []}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "valid nested tree three levels deep",
+        "data": {
+          "method": "get",
+          "path": "/tree",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"name\": \"a\", \"children\": [{\"name\": \"b\", \"children\": [{\"name\": \"c\"}]}]}"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "invalid deeply nested child missing required name",
+        "data": {
+          "method": "get",
+          "path": "/tree",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"name\": \"a\", \"children\": [{\"name\": \"b\", \"children\": [{}]}]}"
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/external_refs/request_body/bodies.yaml
+++ b/spec/openapi_test_suite/external_refs/request_body/bodies.yaml
@@ -1,0 +1,11 @@
+CreateUser:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        unevaluatedProperties: false
+        required: [name]
+        properties:
+          name:
+            type: string

--- a/spec/openapi_test_suite/external_refs/request_body/openapi.yaml
+++ b/spec/openapi_test_suite/external_refs/request_body/openapi.yaml
@@ -1,0 +1,12 @@
+openapi: 3.1.0
+info:
+  title: External RequestBody refs
+  version: "1.0"
+paths:
+  /users:
+    post:
+      requestBody:
+        $ref: './bodies.yaml#/CreateUser'
+      responses:
+        '201':
+          description: Created

--- a/spec/openapi_test_suite/external_refs/request_body/tests.json
+++ b/spec/openapi_test_suite/external_refs/request_body/tests.json
@@ -1,0 +1,33 @@
+[
+  {
+    "description": "external $ref to a RequestBody",
+    "tests": [
+      {
+        "description": "valid body passes",
+        "data": {
+          "method": "post",
+          "path": "/users",
+          "request": {
+            "headers": {"Content-Type": "application/json"},
+            "body": "{\"name\": \"Alice\"}"
+          },
+          "response": {"status": 201, "headers": {}, "body": ""}
+        },
+        "valid": true
+      },
+      {
+        "description": "body missing required name fails",
+        "data": {
+          "method": "post",
+          "path": "/users",
+          "request": {
+            "headers": {"Content-Type": "application/json"},
+            "body": "{}"
+          },
+          "response": {"status": 201, "headers": {}, "body": ""}
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/skooma/external_refs_coverage_spec.rb
+++ b/spec/skooma/external_refs_coverage_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe "External $ref coverage" do
+  def fresh_coverage(schema)
+    storage = Skooma::CoverageStore.new(
+      file_path: File.join(Dir.mktmpdir, "coverage.json")
+    )
+    Skooma::Coverage.new(schema, mode: :report, storage: storage)
+  end
+
+  context "PathItem external $ref" do
+    let(:schema) { load_external_refs_fixture("path_item") }
+    let(:coverage) { fresh_coverage(schema) }
+
+    it "enumerates responses defined in the external file" do
+      expect(coverage.defined_paths).to include(["get", "/health", "200"])
+    end
+
+    it "marks the endpoint covered after a valid request is tracked" do
+      result = schema.evaluate(
+        "method" => "get",
+        "path" => "/health",
+        "request" => {"headers" => {"Content-Type" => "application/json"}},
+        "response" => {"status" => 200, "headers" => {"Content-Type" => "application/json"}, "body" => '{"status": "ok"}'}
+      )
+      expect(result).to be_valid
+
+      coverage.track_request(result)
+      expect(coverage.covered_paths).to include(["get", "/health", "200"])
+      expect(coverage.uncovered_paths).to be_empty
+    end
+  end
+
+  context "external Response $ref (basic fixture)" do
+    let(:schema) { load_external_refs_fixture("basic") }
+    let(:coverage) { fresh_coverage(schema) }
+
+    it "enumerates both inline and externally-referenced endpoint responses" do
+      expect(coverage.defined_paths).to include(
+        ["get", "/users", "200"],
+        ["get", "/users/{id}", "200"]
+      )
+    end
+
+    it "marks endpoints covered as requests are tracked" do
+      result = schema.evaluate(
+        "method" => "get",
+        "path" => "/users",
+        "request" => {"headers" => {"Content-Type" => "application/json"}},
+        "response" => {"status" => 200, "headers" => {"Content-Type" => "application/json"}, "body" => '[{"id": 1, "name": "Alice"}]'}
+      )
+      expect(result).to be_valid
+      coverage.track_request(result)
+
+      expect(coverage.covered_paths).to include(["get", "/users", "200"])
+      expect(coverage.uncovered_paths).to include(["get", "/users/{id}", "200"])
+    end
+  end
+end

--- a/spec/skooma/external_refs_errors_spec.rb
+++ b/spec/skooma/external_refs_errors_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe "External $ref error reporting" do
+  def build_fixture_dir(files)
+    dir = Dir.mktmpdir("skooma_ext_refs_")
+    files.each { |name, content| File.write(File.join(dir, name), content) }
+    dir
+  end
+
+  it "raises a descriptive error when an external file does not exist" do
+    dir = build_fixture_dir(
+      "openapi.yaml" => <<~YAML
+        openapi: 3.1.0
+        info: {title: t, version: "1"}
+        paths:
+          /x:
+            get:
+              responses:
+                '200':
+                  $ref: './missing.yaml#/Response'
+      YAML
+    )
+
+    expect { load_external_refs_openapi(dir) }
+      .to raise_error(JSONSkooma::Sources::Error, /missing\.yaml/)
+  end
+
+  it "raises a descriptive error when the fragment does not exist in the external file" do
+    dir = build_fixture_dir(
+      "openapi.yaml" => <<~YAML,
+        openapi: 3.1.0
+        info: {title: t, version: "1"}
+        paths:
+          /x:
+            get:
+              responses:
+                '200':
+                  $ref: './responses.yaml#/DoesNotExist'
+      YAML
+      "responses.yaml" => <<~YAML
+        SomeOtherResponse:
+          description: OK
+      YAML
+    )
+
+    expect { load_external_refs_openapi(dir) }
+      .to raise_error(JSONSkooma::RegistryError, /Could not resolve.*DoesNotExist/)
+  end
+end

--- a/spec/skooma/external_refs_spec.rb
+++ b/spec/skooma/external_refs_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe "External $ref resolution" do
+  Dir["#{ExternalRefsHelpers::FIXTURES_DIR}/*"].sort.each do |case_dir|
+    next unless File.directory?(case_dir)
+    tests_file = File.join(case_dir, "tests.json")
+    next unless File.exist?(tests_file)
+    next unless Dir["#{case_dir}/openapi.{yaml,yml,json}"].first
+
+    case_name = File.basename(case_dir)
+
+    context "fixture: #{case_name}" do
+      let(:schema) { load_external_refs_fixture(case_name) }
+
+      JSON.parse(File.read(tests_file)).each do |test_case|
+        context test_case["description"] do
+          it "contains a valid openapi schema" do
+            result = schema.validate
+            expect(result).to be_valid, <<~MSG
+              Expected schema to be valid.
+
+              Validation output:
+              #{JSON.pretty_generate(result.output(:detailed))}
+            MSG
+          end
+
+          test_case["tests"].each do |test|
+            it test["description"] do
+              result = schema.evaluate(test["data"])
+
+              expect(result.valid?).to eq(test["valid"]), <<~MSG
+                Expected response to be #{test["valid"] ? "valid" : "invalid"}.
+
+                Data:
+                #{JSON.pretty_generate(test["data"])}
+
+                Validation output:
+                #{JSON.pretty_generate(result.output(:detailed))}
+              MSG
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require "skooma"
+require_relative "support/external_refs"
 
 RSpec.configure do |config|
+  config.include ExternalRefsHelpers
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 

--- a/spec/support/external_refs.rb
+++ b/spec/support/external_refs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "securerandom"
+
+module ExternalRefsHelpers
+  FIXTURES_DIR = File.expand_path("../openapi_test_suite/external_refs", __dir__)
+
+  def load_external_refs_fixture(case_name)
+    root_file = Dir["#{FIXTURES_DIR}/#{case_name}/openapi.{yaml,yml,json}"].first
+    load_external_refs_openapi(File.dirname(root_file), filename: File.basename(root_file), tag: case_name)
+  end
+
+  def load_external_refs_openapi(dir, filename: "openapi.yaml", tag: "adhoc")
+    suffix = SecureRandom.hex(4)
+    registry = Skooma.create_registry(name: "ext_refs_#{tag}_#{suffix}")
+    base_uri = "https://skoomarb.dev/fixtures/#{tag}/#{suffix}/"
+    registry.add_source(base_uri, JSONSkooma::Sources::Local.new(dir))
+    registry.schema(
+      URI.parse("#{base_uri}#{filename}"),
+      schema_class: Skooma::Objects::OpenAPI
+    )
+  end
+end


### PR DESCRIPTION
## Summary

References like `$ref: './responses.yaml#/UsersResponse'` now resolve against the spec file's directory (or any source registered on the registry), so a large OpenAPI document can be split across files.

Closes #45

## How it works

json_skooma 0.2.7 raises a typed `UnexpectedSchemaClassError` when upstream resolution finds that a ref's fragment points at a non-schema node inside a raw document (the usual case for external refs into plain YAML maps). The new `Skooma::ExternalRefs` module rescues it, loads the raw document through the registry's sources, evaluates the fragment pointer, and wraps the subtree as the referrer's own class — so a `$ref` under `responses` loads as a Response, under `parameters` as a Parameter, under `schema:` as a JSON Schema, and so on. The wrapped schema registers itself in the registry cache, so resolution cost is paid once.

- Chained external refs (A → B → C across files) and self-recursive schemas work.
- Only local files resolve by default; other sources (e.g. HTTP) can be registered on the registry — see the new README section.
- `json_skooma` dependency bumped to `~> 0.2.7` (0.2.6 was yanked due to a packaging issue).

## Test plan

- New fixture-driven suite (`spec/openapi_test_suite/external_refs/`): basic refs across response/parameter/schema files, headers, path items, request bodies, and recursive schemas.
- Error-reporting specs: missing external file, missing fragment.
- Coverage-integration specs: externally-referenced endpoints are enumerated and tracked by `Skooma::Coverage`.
- Full suite green against the released json_skooma 0.2.7: 265 examples, 0 failures; standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)