### PR TITLE
Expand parameter deserialization across all locations with param-aware coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning].
 
 - Support for external `$ref`s in OpenAPI documents. References like `$ref: './responses.yaml#/UsersResponse'` now resolve against the spec file's directory (or any source registered on the registry) and are wrapped with the appropriate OpenAPI object type — Response, Parameter, Header, RequestBody, PathItem, or a plain JSON Schema for `schema:` refs. Chained and self-recursive external refs are supported. ([@skryukov])
 - Support array-valued query parameters: respect the `style` and `explode` keywords (`form`, `spaceDelimited`, and `pipeDelimited` styles), coerce array items to the declared `items` type, and map the non-standard bracket convention (`ids[]=1&ids[]=2`) to array params. ([@dslh])
+- Support object-valued query parameters declared with the `deepObject` style (`filter[id]=1&filter[name]=foo`), coercing each property to its declared type. Parameter coercion now descends into array items (positional `prefixItems` first, then `items`) and object properties (`properties` first, then `additionalProperties`), while request/response bodies keep their JSON-native types.
+- Support array-valued header (`simple` style) and cookie (`form` style) parameters, splitting the delimited value and coercing each item to the declared `items` type.
+- Support cookie parameters, which were previously ignored entirely.
+- Support array-valued path parameters across the `simple`, `label`, and `matrix` styles (with `explode`), coercing each item to the declared `items` type.
+- Parse `content`-typed parameters (e.g. `content: {application/json: …}`) using the parameter's own media type before validation, instead of validating the raw string against a media type taken from the response. **Behavior change:** such values are now decoded per their media type (e.g. JSON), so a value that previously passed as a raw string may need to be sent in its serialized form (e.g. `"100"` rather than `100` for a JSON string).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,53 @@ As a convenience, the non-standard Rails/Rack bracket convention is also recogni
 The bracket form is only used when the parameter declares `type: array` and
 the query string contains no exact `ids` key.
 
+### Object query parameters
+
+Skooma deserializes object-valued query parameters declared with the `deepObject`
+style, gathering the bracketed members and coercing each property to the type
+declared in its `properties` schema:
+
+```yaml
+- in: query
+  name: filter
+  style: deepObject
+  explode: true
+  schema:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+```
+
+```
+GET /things?filter[id]=1&filter[name]=foo # filter => { "id" => 1, "name" => "foo" }
+```
+
+### Header and cookie parameters
+
+Array-valued header (`simple` style) and cookie (`form` style) parameters are
+deserialized from their delimited form and each item is coerced to the declared
+`items` type:
+
+```
+X-Ids: 1,2,3            # X-Ids  => [1, 2, 3]
+Cookie: ids=1,2,3       # ids    => [1, 2, 3]
+```
+
+### Path parameters
+
+Array-valued path parameters are deserialized according to their `style`
+(`simple`, `label`, `matrix`) and `explode` keywords, with each item coerced to
+the declared `items` type:
+
+```
+GET /things/1,2,3          # simple:            id => [1, 2, 3]
+GET /things/.1.2.3         # label, explode:    id => [1, 2, 3]
+GET /things/;id=1;id=2     # matrix, explode:   id => [1, 2]
+```
+
 ## Alternatives
 
 - [openapi_first](https://github.com/ahx/openapi_first)
@@ -236,8 +283,7 @@ the query string contains no exact `ids` key.
 ## Feature plans
 
 - Full OpenAPI 3.1.0 support:
-  - respect `style` and `explode` keywords for path, header, and cookie parameters
-    (already supported for query parameters)
+  - object-valued path and form-encoded query parameters
   - xml
 - Callbacks and webhooks validations
 - Example validations

--- a/lib/skooma/instance.rb
+++ b/lib/skooma/instance.rb
@@ -40,9 +40,68 @@ module Skooma
 
       def self.coerce_array_items(value, items_schema)
         return value unless value.is_a?(Array)
-        return value unless items_schema.is_a?(JSONSkooma::JSONSchema) && items_schema.type == "object"
+        return value unless schema_object?(items_schema)
 
         value.map { |item| item.is_a?(String) ? coerce_value(item, items_schema) : item }
+      end
+
+      # Recursive coercion for *parameters* only. Parameter values arrive as
+      # all-strings, so we descend into array items (positional `prefixItems`
+      # first, then `items`) and object properties (`properties` first, then
+      # `additionalProperties`), coercing each to its declared type.
+      # Request/response *bodies* are only shallowly coerced (top level, via
+      # `coerce` above), so a *nested* JSON body value like `{"count": "5"}`
+      # against `integer` stays invalid.
+      def deep_coerce(json)
+        return if value.nil?
+
+        Coercible.deep_coerce_value(value, json)
+      end
+
+      def self.deep_coerce_value(value, json)
+        return value if value.nil?
+
+        case json["type"]
+        when "array"
+          return value unless value.is_a?(Array)
+
+          prefix_items = json["prefixItems"]
+          items = json["items"]
+
+          value.map.with_index do |item, index|
+            schema = prefix_schema(prefix_items, index) || items
+            schema_object?(schema) ? deep_coerce_value(item, schema) : item
+          end
+        when "object"
+          return value unless value.is_a?(Hash)
+
+          properties = json["properties"]
+          additional_properties = json["additionalProperties"]
+
+          value.each_with_object({}) do |(key, item), coerced|
+            schema = properties.respond_to?(:key?) ? properties[key] : nil
+            schema ||= additional_properties
+            coerced[key] = schema_object?(schema) ? deep_coerce_value(item, schema) : item
+          end
+        else
+          # Scalar schema: only scalar values are coercible. A structural value
+          # here means a type mismatch (e.g. `deepObject` against a scalar
+          # schema) — leave it for validation to reject rather than coerce.
+          (value.is_a?(Hash) || value.is_a?(Array)) ? value : coerce_value(value, json)
+        end
+      end
+
+      # True when `node` is a real subschema (a JSON object), excluding boolean
+      # schemas like `items: true`.
+      def self.schema_object?(node)
+        node.is_a?(JSONSkooma::JSONSchema) && node.type == "object"
+      end
+
+      # The positional subschema for `index` when `prefixItems` is present.
+      def self.prefix_schema(prefix_items, index)
+        return unless prefix_items.is_a?(JSONSkooma::JSONNode) && prefix_items.type == "array"
+
+        prefix_items[index]
       end
     end
 

--- a/lib/skooma/objects/parameter/keywords/content.rb
+++ b/lib/skooma/objects/parameter/keywords/content.rb
@@ -13,7 +13,25 @@ module Skooma
           def evaluate(instance, result)
             return if instance.value.nil?
 
-            super(ValueParser.call(instance, result), result)
+            value = ValueParser.call(instance, result)
+            return result.discard if value.nil?
+
+            # A parameter's `content` declares the media type its value is
+            # serialized in (typically exactly one entry). Parse the raw value
+            # with the matching body parser, then validate the parsed value
+            # against that media type's schema. (The header version picks the
+            # media type from the response Content-Type, which is wrong here.)
+            json.each do |media_type, media_type_object|
+              parsed = Instance::Attribute.new(
+                BodyParsers[media_type].call(value.value),
+                key: value.key,
+                parent: value.parent
+              )
+              result.call(parsed, media_type) do |media_type_result|
+                media_type_object.evaluate(parsed, media_type_result)
+                result.failure("Invalid content for media type #{media_type}") unless media_type_result.passed?
+              end
+            end
           end
         end
       end

--- a/lib/skooma/objects/parameter/keywords/schema.rb
+++ b/lib/skooma/objects/parameter/keywords/schema.rb
@@ -12,7 +12,10 @@ module Skooma
             value = ValueParser.call(instance, result, array: ValueParser.array_param?(parent_schema))
             return result.discard if value.nil?
 
-            super(value, result)
+            # Parameters coerce deeply (their values arrive as all-strings);
+            # bodies keep OAS31::Schema's shallow `coerce`, so body validation
+            # is unaffected.
+            json.evaluate(value.deep_coerce(json), result)
           end
         end
       end

--- a/lib/skooma/objects/parameter/keywords/value_parser.rb
+++ b/lib/skooma/objects/parameter/keywords/value_parser.rb
@@ -10,36 +10,38 @@ module Skooma
           # https://spec.openapis.org/oas/v3.1.0#style-values
           ARRAY_STYLE_DELIMITERS = {
             "form" => ",",
+            "simple" => ",",
             "spaceDelimited" => " ",
             "pipeDelimited" => "|"
           }.freeze
 
+          # Default `style` per parameter location (OpenAPI 3.1 parameter object).
+          DEFAULT_STYLE = {
+            "query" => "form",
+            "path" => "simple",
+            "header" => "simple",
+            "cookie" => "form"
+          }.freeze
+
           class << self
             def call(instance, result, array: false)
-              type = result.sibling(instance, "in")&.annotation
-              raise Error, "Missing `in` key #{result.path}" unless type
+              location = result.sibling(instance, "in")&.annotation
+              raise Error, "Missing `in` key #{result.path}" unless location
 
               key = result.sibling(instance, "name")&.annotation
               raise Error, "Missing `name` key #{result.path}" unless key
 
-              case type
+              case location
               when "query"
                 query_param_value(instance, result, key, array: array)
               when "header"
-                instance["headers"][key]
+                header_param_value(instance, result, key, array: array)
               when "path"
-                path_item_result = result.parent
-                path_item_result = path_item_result.parent until path_item_result.key.start_with?("/")
-
-                Instance::Attribute.new(
-                  path_item_result.annotation["path_attributes"][key],
-                  key: "path",
-                  parent: instance["path"]
-                )
+                path_param_value(instance, result, key, array: array)
               when "cookie"
-                # instance["headers"]["Cookie"]
+                cookie_param_value(instance, result, key, array: array)
               else
-                raise Error, "Unknown location: #{type}"
+                raise Error, "Unknown location: #{location}"
               end
             end
 
@@ -51,6 +53,14 @@ module Skooma
             private
 
             def query_param_value(instance, result, key, array:)
+              # `deepObject` spreads an object across bracketed keys
+              # (`filter[a]=1&filter[b]=2`) and is the only style that consumes
+              # more than one query key, so it is handled before the scalar/array
+              # path.
+              if result.sibling(instance, "style")&.annotation == "deepObject"
+                return deep_object_value(instance, key)
+              end
+
               params = parse_query(instance["query"]&.value)
               values = params[key]
               # Support the non-standard Rails/Rack/PHP bracket convention
@@ -69,6 +79,106 @@ module Skooma
               Instance::Attribute.new(value, key: key, parent: instance["query"])
             end
 
+            # Header values are a single string; an array is delimited inline
+            # (`simple` style, comma-separated). `explode` does not change the
+            # serialization for headers, so it is not consulted.
+            def header_param_value(instance, result, key, array:)
+              attribute = instance["headers"][key]
+              return attribute unless array
+              return attribute if attribute.nil? || attribute.value.nil?
+
+              Instance::Attribute.new(
+                split_delimited(attribute.value, style_for(result, instance, "header")),
+                key: key,
+                parent: instance["headers"]
+              )
+            end
+
+            # Path values are a single captured segment. `simple` (the default)
+            # is comma-delimited; `label` carries a `.` prefix and `matrix` a
+            # `;name=` prefix, and for those two `explode` switches the item
+            # separator. Object-valued path params are out of scope.
+            def path_param_value(instance, result, key, array:)
+              raw = path_attributes(result)[key]
+              return nil if raw.nil?
+
+              style = style_for(result, instance, "path")
+              value =
+                if array
+                  explode = result.sibling(instance, "explode")&.annotation || false
+                  deserialize_path_array(raw, key, style, explode)
+                else
+                  strip_path_prefix(raw, key, style)
+                end
+
+              Instance::Attribute.new(value, key: "path", parent: instance["path"])
+            end
+
+            def path_attributes(result)
+              path_item_result = result.parent
+              path_item_result = path_item_result.parent until path_item_result.key.start_with?("/")
+              path_item_result.annotation["path_attributes"]
+            end
+
+            def strip_path_prefix(raw, name, style)
+              case style
+              when "label" then raw.delete_prefix(".")
+              when "matrix" then raw.delete_prefix(";#{name}=")
+              else raw
+              end
+            end
+
+            def deserialize_path_array(raw, name, style, explode)
+              case style
+              when "label"
+                strip_path_prefix(raw, name, style).split(explode ? "." : ",")
+              when "matrix"
+                if explode
+                  # `;id=3;id=4;id=5` — keep only this parameter's pairs
+                  raw.delete_prefix(";").split(";").map { |pair|
+                    pair_name, pair_value = pair.split("=", 2)
+                    pair_value if pair_name == name
+                  }.compact
+                else
+                  # `;id=3,4,5`
+                  strip_path_prefix(raw, name, style).split(",")
+                end
+              else # simple: `3,4,5`
+                raw.split(",")
+              end
+            end
+
+            # Cookies carry one string per name; an array is a delimited inline
+            # value (`form` style, comma-separated). `explode` is not consulted
+            # because cookies cannot repeat a name.
+            def cookie_param_value(instance, result, key, array:)
+              raw = parse_cookies(instance["headers"]["Cookie"]&.value)[key]
+              return nil if raw.nil?
+
+              value = array ? split_delimited(raw, style_for(result, instance, "cookie")) : raw
+              Instance::Attribute.new(value, key: key, parent: instance["headers"])
+            end
+
+            # deepObject: gather the bracketed properties of `key` into a hash.
+            # Property values stay strings; type coercion happens later via
+            # Instance#deep_coerce against the object's `properties` schema.
+            # (Nested objects and array-valued properties are out of scope.)
+            def deep_object_value(instance, key)
+              prefix = "#{key}["
+              object = {}
+              parse_query(instance["query"]&.value).each do |param_key, values|
+                next unless param_key.start_with?(prefix) && param_key.end_with?("]")
+
+                property = param_key.delete_prefix(prefix).delete_suffix("]")
+                next if property.empty?
+
+                object[property] = values.last
+              end
+              return nil if object.empty?
+
+              Instance::Attribute.new(object, key: key, parent: instance["query"])
+            end
+
             def parse_query(query_string)
               params = {}
               query_string.to_s.split(/[&;]/).each do |pair|
@@ -81,15 +191,38 @@ module Skooma
               params
             end
 
+            # Cookie values are opaque (RFC 6265): split into name=value pairs
+            # but do not percent-decode (unlike query strings), so values such as
+            # base64 tokens stay intact.
+            def parse_cookies(cookie_string)
+              cookies = {}
+              cookie_string.to_s.split(/;\s*/).each do |pair|
+                name, value = pair.split("=", 2)
+                next if name.nil? || name.empty?
+
+                cookies[name] = value
+              end
+
+              cookies
+            end
+
             def deserialize_array(values, instance, result)
-              style = result.sibling(instance, "style")&.annotation || "form"
+              style = style_for(result, instance, "query")
               explode = result.sibling(instance, "explode")&.annotation
               explode = style == "form" if explode.nil?
 
               # exploded arrays are serialized as repeated keys (`ids=1&ids=2`)
               return values.compact if explode
 
-              values.last.split(ARRAY_STYLE_DELIMITERS.fetch(style, ","))
+              split_delimited(values.last, style)
+            end
+
+            def split_delimited(raw, style)
+              raw.split(ARRAY_STYLE_DELIMITERS.fetch(style, ","))
+            end
+
+            def style_for(result, instance, location)
+              result.sibling(instance, "style")&.annotation || DEFAULT_STYLE.fetch(location, "form")
             end
           end
         end

--- a/spec/openapi_test_suite/content_params.json
+++ b/spec/openapi_test_suite/content_params.json
@@ -1,0 +1,176 @@
+[
+  {
+    "description": "Content-typed query parameters are parsed as their media type",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "f",
+                "required": true,
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "object",
+                      "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"}
+                      },
+                      "required": ["a"]
+                    }
+                  }
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a JSON object value is parsed and validated against the schema",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "f=%7B%22a%22%3A1%2C%22b%22%3A%22x%22%7D",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      },
+      {
+        "description": "JSON-native types are respected (a string where an integer is required is invalid)",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "f=%7B%22a%22%3A%221%22%7D",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      },
+      {
+        "description": "a missing required property is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "f=%7B%22b%22%3A%22x%22%7D",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      },
+      {
+        "description": "an unparseable value fails validation rather than raising",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "f=notjson",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      },
+      {
+        "description": "a missing required content param is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "other=1",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Content-typed header parameters are parsed as their media type",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "header",
+                "name": "X-Count",
+                "required": true,
+                "content": {
+                  "application/json": {
+                    "schema": {"type": "integer", "minimum": 1}
+                  }
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a JSON number header is parsed to an integer and validated",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "X-Count": "5"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      },
+      {
+        "description": "a parsed value is validated against the schema (0 violates minimum)",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "X-Count": "0"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      },
+      {
+        "description": "a missing required content header is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/cookie_params.json
+++ b/spec/openapi_test_suite/cookie_params.json
@@ -1,0 +1,250 @@
+[
+  {
+    "description": "Scalar cookie parameters",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "cookie",
+                "name": "session_id",
+                "required": true,
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a cookie value is read and coerced to the declared type",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "session_id=42"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a cookie value that fails its type is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "session_id=abc"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "the named cookie is selected from among several",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "other=1; session_id=42; last=9"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a missing required cookie is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "other=1"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Array-valued cookie parameters (form style)",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "cookie",
+                "name": "ids",
+                "required": true,
+                "style": "form",
+                "explode": false,
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "maxItems": 3
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a comma-separated cookie is split and coerced",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "ids=1,2,3"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "too many items violates maxItems",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "ids=1,2,3,4"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "an item that fails its type is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "Cookie": "ids=1,x"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Optional cookie parameters",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "cookie",
+                "name": "session_id",
+                "required": false,
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "an absent optional cookie is skipped",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/header_array_params.json
+++ b/spec/openapi_test_suite/header_array_params.json
@@ -1,0 +1,181 @@
+[
+  {
+    "description": "Array-valued header parameters (simple style)",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "header",
+                "name": "X-Ids",
+                "required": true,
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "maxItems": 3
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a comma-separated header is split and coerced to the item type",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "X-Ids": "1,2,3"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a single value becomes a one-element array",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "X-Ids": "1"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "too many items violates maxItems",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "X-Ids": "1,2,3,4"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "an item that fails its type is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json", "X-Ids": "1,x"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a missing required array header is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Optional array-valued header parameters",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "header",
+                "name": "X-Ids",
+                "required": false,
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "an absent optional array header is skipped",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/header_params.json
+++ b/spec/openapi_test_suite/header_params.json
@@ -108,7 +108,7 @@
             "headers": {
               "Content-Type": "application/json",
               "X-Expires-At": "2020-01-01T00:00:00Z",
-              "X-Rate-Limit": "100"
+              "X-Rate-Limit": "\"100\""
             }
           },
           "response": {
@@ -129,7 +129,7 @@
           "request": {
             "headers": {
               "Content-Type": "application/json",
-              "X-Rate-Limit": "100"
+              "X-Rate-Limit": "\"100\""
             }
           },
           "response": {
@@ -172,7 +172,7 @@
             "headers": {
               "Content-Type": "application/json",
               "X-Expires-At": "2020-01-01T00:00:00Z",
-              "X-Rate-Limit": "1"
+              "X-Rate-Limit": "\"1\""
             }
           },
           "response": {
@@ -194,7 +194,7 @@
             "headers": {
               "Content-Type": "application/json",
               "X-Expires-At": "Christmas",
-              "X-Rate-Limit": "100"
+              "X-Rate-Limit": "\"100\""
             }
           },
           "response": {

--- a/spec/openapi_test_suite/path_array_params.json
+++ b/spec/openapi_test_suite/path_array_params.json
@@ -1,0 +1,229 @@
+[
+  {
+    "description": "Array path params with the default simple style",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/things/{id}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "schema": {
+                  "type": "array",
+                  "items": {"type": "integer"},
+                  "maxItems": 3
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a comma-separated segment is split and items are coerced",
+        "data": {
+          "method": "get",
+          "path": "/things/1,2,3",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      },
+      {
+        "description": "too many items violates maxItems",
+        "data": {
+          "method": "get",
+          "path": "/things/1,2,3,4",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      },
+      {
+        "description": "an item that fails its type is invalid",
+        "data": {
+          "method": "get",
+          "path": "/things/1,x",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Array path params with label style",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/things/{id}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "style": "label",
+                "explode": false,
+                "schema": {"type": "array", "items": {"type": "integer"}}
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "non-exploded label values are dot-prefixed and comma-separated",
+        "data": {
+          "method": "get",
+          "path": "/things/.1,2,3",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "Array path params with label style and explode=true",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/things/{id}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "style": "label",
+                "explode": true,
+                "schema": {"type": "array", "items": {"type": "integer"}}
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "exploded label values are dot-separated",
+        "data": {
+          "method": "get",
+          "path": "/things/.1.2.3",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "Array path params with matrix style",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/things/{id}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "style": "matrix",
+                "explode": false,
+                "schema": {"type": "array", "items": {"type": "integer"}}
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "non-exploded matrix values are name-prefixed and comma-separated",
+        "data": {
+          "method": "get",
+          "path": "/things/;id=1,2,3",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "Array path params with matrix style and explode=true",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/things/{id}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "style": "matrix",
+                "explode": true,
+                "schema": {"type": "array", "items": {"type": "integer"}}
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {"application/json": {"schema": {}}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "exploded matrix values repeat the name per item",
+        "data": {
+          "method": "get",
+          "path": "/things/;id=1;id=2;id=3",
+          "request": {"headers": {"Content-Type": "application/json"}},
+          "response": {"status": 200, "headers": {"Content-Type": "application/json"}, "body": null}
+        },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/query_object_params.json
+++ b/spec/openapi_test_suite/query_object_params.json
@@ -1,0 +1,313 @@
+[
+  {
+    "description": "deepObject query params coerce and validate their properties",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "filter",
+                "required": true,
+                "style": "deepObject",
+                "explode": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "b": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["a"]
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "bracketed properties are gathered and the integer property is coerced",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "filter[a]=1&filter[b]=x",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "url-encoded brackets are gathered the same way",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "filter%5Ba%5D=2&filter%5Bb%5D=y",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a property that fails its type is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "filter[a]=x",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a coerced value is validated against the property schema (0 violates minimum 1)",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "filter[a]=0",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a missing required property is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "filter[b]=x",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a missing required deepObject param is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "other=1",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "Optional deepObject query params",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "api",
+        "version": "1.0.0"
+      },
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "filter",
+                "required": false,
+                "style": "deepObject",
+                "explode": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "a": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Success",
+                "content": {
+                  "application/json": {
+                    "schema": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "an absent optional deepObject param is skipped",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "other=1",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a present optional deepObject param is coerced and validated",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "filter[a]=5",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "deepObject query params coerce additionalProperties-typed members",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "counts",
+                "required": true,
+                "style": "deepObject",
+                "explode": true,
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {"type": "integer", "minimum": 1}
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "members are coerced to integers",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "counts[a]=1&counts[b]=2",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a member failing the schema is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "counts[a]=0",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a non-integer member is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "counts[a]=x",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/query_tuple_params.json
+++ b/spec/openapi_test_suite/query_tuple_params.json
@@ -1,0 +1,100 @@
+[
+  {
+    "description": "tuple-typed query params coerce prefixItems positionally",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "pair",
+                "required": true,
+                "style": "form",
+                "explode": false,
+                "schema": {
+                  "type": "array",
+                  "prefixItems": [{"type": "integer"}, {"type": "string"}],
+                  "items": {"type": "integer"}
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "positions coerce against their prefix schema",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "pair=1,a",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "trailing positions coerce against items",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "pair=1,a,2,3",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a position violating its prefix schema is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "pair=x,a",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a trailing position violating items is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "pair=1,a,b",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Builds on #56 to cover the rest of the OpenAPI parameter serialization surface. Parameters are distinguished from request/response bodies: parameter values arrive as all-strings and are now **deeply coerced** to their declared types, while bodies keep their JSON-native types (a nested body value like `{"count": "5"}` against `integer` still correctly fails).

New coverage:

- **query**: `deepObject` objects (`filter[id]=1&filter[name]=foo`), with property coercion via `properties` and `additionalProperties`
- **header**: `simple`-style arrays (`X-Ids: 1,2,3`)
- **cookie**: scalar and `form`-style array parameters — previously ignored entirely
- **path**: `simple`/`label`/`matrix` arrays, explode-aware; matrix-explode keeps only pairs matching the parameter name
- **arrays**: positional `prefixItems` coercion with `items` fallback
- **content-typed params**: parsed with the parameter's *own* media type (via `BodyParsers`) before validation

Internally, `ValueParser` is refactored into per-location extraction adapters over a shared deserialize core, and `Instance#deep_coerce` handles the recursive coercion.

## ⚠️ Behavior change

`content`-typed parameter values (e.g. `content: {application/json: ...}`) were previously validated as raw strings against a media type taken from the **response** Content-Type — non-conformant and effectively never parsed. They are now decoded per the parameter's own media type. A value that previously passed as a raw string may need its serialized form (e.g. `"100"` with quotes for a JSON string). The `X-Rate-Limit` fixture is updated accordingly.

## Out of scope (fail validation cleanly, no crashes — probe-verified)

- Nested objects / array-valued properties in `deepObject`
- Object-valued path parameters

## Test plan

- 5 new fixture files + extensions: `query_object_params`, `query_tuple_params`, `header_array_params`, `cookie_params`, `path_array_params`, `content_params` (~1,200 lines of cases, including invalid-value, required-absent, and malformed-JSON cases)
- Full suite: 562 examples, 0 failures; standardrb clean; verified on top of merged #56
- Adversarially probed: malformed JSON in content params fails validation without crashing, cookie values keep base64 `=` padding, empty header arrays don't crash, body coercion semantics unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)