### PR TITLE
Add object-valued path and form-style query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- Support object-valued path parameters (`simple`, `label`, and `matrix` styles, explode-aware) and `form`-style object query parameters. Exploded form objects (`?x=1&y=2`) are gathered by matching the schema's `properties` names; non-exploded forms flatten under the parameter's name (`?point=x,1,y,2`). Properties are coerced to their declared types. ([@skryukov])
+
 - Support for external `$ref`s in OpenAPI documents. References like `$ref: './responses.yaml#/UsersResponse'` now resolve against the spec file's directory (or any source registered on the registry) and are wrapped with the appropriate OpenAPI object type — Response, Parameter, Header, RequestBody, PathItem, or a plain JSON Schema for `schema:` refs. Chained and self-recursive external refs are supported. ([@skryukov])
 - Support array-valued query parameters: respect the `style` and `explode` keywords (`form`, `spaceDelimited`, and `pipeDelimited` styles), coerce array items to the declared `items` type, and map the non-standard bracket convention (`ids[]=1&ids[]=2`) to array params. ([@dslh])
 - Support object-valued query parameters declared with the `deepObject` style (`filter[id]=1&filter[name]=foo`), coercing each property to its declared type. Parameter coercion now descends into array items (positional `prefixItems` first, then `items`) and object properties (`properties` first, then `additionalProperties`), while request/response bodies keep their JSON-native types.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,19 @@ declared in its `properties` schema:
 GET /things?filter[id]=1&filter[name]=foo # filter => { "id" => 1, "name" => "foo" }
 ```
 
+The default `form` style is also supported. Exploded form objects (the default)
+drop the parameter name — each property declared in the schema becomes its own
+query key — while non-exploded objects flatten under the parameter's name:
+
+```
+GET /things?x=1&y=2        # form, explode:  point => { "x" => 1, "y" => 2 }
+GET /things?point=x,1,y,2  # form:           point => { "x" => 1, "y" => 2 }
+```
+
+Note that exploded form objects are gathered by matching the schema's
+`properties` names, so members allowed only via `additionalProperties` are not
+recognized.
+
 ### Header and cookie parameters
 
 Array-valued header (`simple` style) and cookie (`form` style) parameters are
@@ -275,6 +288,15 @@ GET /things/.1.2.3         # label, explode:    id => [1, 2, 3]
 GET /things/;id=1;id=2     # matrix, explode:   id => [1, 2]
 ```
 
+Object-valued path parameters flatten their properties into the segment and are
+rebuilt with each property coerced via the `properties` schema:
+
+```
+GET /points/x,1,y,2        # simple:            point => { "x" => 1, "y" => 2 }
+GET /points/x=1,y=2        # simple, explode:   point => { "x" => 1, "y" => 2 }
+GET /points/;x=1;y=2       # matrix, explode:   point => { "x" => 1, "y" => 2 }
+```
+
 ## Alternatives
 
 - [openapi_first](https://github.com/ahx/openapi_first)
@@ -283,7 +305,6 @@ GET /things/;id=1;id=2     # matrix, explode:   id => [1, 2]
 ## Feature plans
 
 - Full OpenAPI 3.1.0 support:
-  - object-valued path and form-encoded query parameters
   - xml
 - Callbacks and webhooks validations
 - Example validations

--- a/lib/skooma/objects/parameter/keywords/required.rb
+++ b/lib/skooma/objects/parameter/keywords/required.rb
@@ -11,7 +11,7 @@ module Skooma
           def evaluate(instance, result)
             return unless json.value
 
-            value = ValueParser.call(instance, result, array: ValueParser.array_param?(parent_schema))
+            value = ValueParser.call(instance, result, schema: parent_schema["schema"])
             if value&.value.nil?
               result.failure("Parameter is required")
             end

--- a/lib/skooma/objects/parameter/keywords/schema.rb
+++ b/lib/skooma/objects/parameter/keywords/schema.rb
@@ -9,7 +9,7 @@ module Skooma
           self.depends_on = %w[in name style explode allowReserved allowEmptyValue]
 
           def evaluate(instance, result)
-            value = ValueParser.call(instance, result, array: ValueParser.array_param?(parent_schema))
+            value = ValueParser.call(instance, result, schema: json)
             return result.discard if value.nil?
 
             # Parameters coerce deeply (their values arrive as all-strings);

--- a/lib/skooma/objects/parameter/keywords/value_parser.rb
+++ b/lib/skooma/objects/parameter/keywords/value_parser.rb
@@ -24,7 +24,7 @@ module Skooma
           }.freeze
 
           class << self
-            def call(instance, result, array: false)
+            def call(instance, result, schema: nil)
               location = result.sibling(instance, "in")&.annotation
               raise Error, "Missing `in` key #{result.path}" unless location
 
@@ -33,26 +33,35 @@ module Skooma
 
               case location
               when "query"
-                query_param_value(instance, result, key, array: array)
+                query_param_value(instance, result, key, schema: schema)
               when "header"
-                header_param_value(instance, result, key, array: array)
+                header_param_value(instance, result, key, schema: schema)
               when "path"
-                path_param_value(instance, result, key, array: array)
+                path_param_value(instance, result, key, schema: schema)
               when "cookie"
-                cookie_param_value(instance, result, key, array: array)
+                cookie_param_value(instance, result, key, schema: schema)
               else
                 raise Error, "Unknown location: #{location}"
               end
             end
 
-            def array_param?(parameter)
-              schema = parameter["schema"]
-              schema.is_a?(JSONSkooma::JSONSchema) && schema.type == "object" && schema["type"] == "array"
-            end
-
             private
 
-            def query_param_value(instance, result, key, array:)
+            # The declared shape of the parameter value: :array, :object, or
+            # :primitive (scalars, missing schemas, and `content` params).
+            def shape_of(schema)
+              return :primitive unless schema.is_a?(JSONSkooma::JSONSchema) && schema.type == "object"
+
+              case schema["type"]&.value
+              when "array" then :array
+              when "object" then :object
+              else :primitive
+              end
+            end
+
+            def query_param_value(instance, result, key, schema:)
+              shape = shape_of(schema)
+
               # `deepObject` spreads an object across bracketed keys
               # (`filter[a]=1&filter[b]=2`) and is the only style that consumes
               # more than one query key, so it is handled before the scalar/array
@@ -61,6 +70,11 @@ module Skooma
                 return deep_object_value(instance, key)
               end
 
+              if shape == :object
+                return form_object_value(instance, result, key, schema)
+              end
+
+              array = shape == :array
               params = parse_query(instance["query"]&.value)
               values = params[key]
               # Support the non-standard Rails/Rack/PHP bracket convention
@@ -81,10 +95,11 @@ module Skooma
 
             # Header values are a single string; an array is delimited inline
             # (`simple` style, comma-separated). `explode` does not change the
-            # serialization for headers, so it is not consulted.
-            def header_param_value(instance, result, key, array:)
+            # serialization for headers, so it is not consulted. Object-valued
+            # headers are out of scope.
+            def header_param_value(instance, result, key, schema:)
               attribute = instance["headers"][key]
-              return attribute unless array
+              return attribute unless shape_of(schema) == :array
               return attribute if attribute.nil? || attribute.value.nil?
 
               Instance::Attribute.new(
@@ -96,17 +111,22 @@ module Skooma
 
             # Path values are a single captured segment. `simple` (the default)
             # is comma-delimited; `label` carries a `.` prefix and `matrix` a
-            # `;name=` prefix, and for those two `explode` switches the item
-            # separator. Object-valued path params are out of scope.
-            def path_param_value(instance, result, key, array:)
+            # `;name=` prefix, and for arrays `explode` switches the item
+            # separator. Objects flatten into the segment as key/value pairs —
+            # comma-interleaved (`role,admin`) or `=`-joined (`role=admin`)
+            # when exploded.
+            def path_param_value(instance, result, key, schema:)
               raw = path_attributes(result)[key]
               return nil if raw.nil?
 
               style = style_for(result, instance, "path")
+              explode = result.sibling(instance, "explode")&.annotation || false
               value =
-                if array
-                  explode = result.sibling(instance, "explode")&.annotation || false
+                case shape_of(schema)
+                when :array
                   deserialize_path_array(raw, key, style, explode)
+                when :object
+                  deserialize_path_object(raw, key, style, explode)
                 else
                   strip_path_prefix(raw, key, style)
                 end
@@ -148,14 +168,39 @@ module Skooma
               end
             end
 
+            # Object path params flatten properties into the segment:
+            #   simple:          `role,admin,name,Alex`
+            #   simple explode:  `role=admin,name=Alex`
+            #   label:           `.role,admin,name,Alex`
+            #   label explode:   `.role=admin.name=Alex`
+            #   matrix:          `;point=role,admin,name,Alex`
+            #   matrix explode:  `;role=admin;name=Alex`
+            # A malformed flattening (odd member count, missing `=`) returns the
+            # raw string so schema validation rejects it.
+            def deserialize_path_object(raw, name, style, explode)
+              members =
+                if explode
+                  body = (style == "matrix") ? raw.delete_prefix(";") : strip_path_prefix(raw, name, style)
+                  separator = {"label" => ".", "matrix" => ";"}.fetch(style, ",")
+                  body.split(separator).map { |pair| pair.split("=", 2) }
+                else
+                  strip_path_prefix(raw, name, style).split(",").each_slice(2).to_a
+                end
+
+              return raw unless members.all? { |pair| pair.size == 2 }
+
+              members.to_h
+            end
+
             # Cookies carry one string per name; an array is a delimited inline
             # value (`form` style, comma-separated). `explode` is not consulted
-            # because cookies cannot repeat a name.
-            def cookie_param_value(instance, result, key, array:)
+            # because cookies cannot repeat a name. Object-valued cookies are
+            # out of scope.
+            def cookie_param_value(instance, result, key, schema:)
               raw = parse_cookies(instance["headers"]["Cookie"]&.value)[key]
               return nil if raw.nil?
 
-              value = array ? split_delimited(raw, style_for(result, instance, "cookie")) : raw
+              value = (shape_of(schema) == :array) ? split_delimited(raw, style_for(result, instance, "cookie")) : raw
               Instance::Attribute.new(value, key: key, parent: instance["headers"])
             end
 
@@ -177,6 +222,41 @@ module Skooma
               return nil if object.empty?
 
               Instance::Attribute.new(object, key: key, parent: instance["query"])
+            end
+
+            # `form`-style object query params (the default style). Exploded
+            # objects drop the parameter name entirely — each declared property
+            # becomes its own query key (`?x=1&y=2`) — so members are gathered
+            # by matching the schema's `properties` names; `additionalProperties`
+            # members cannot be recognized and are out of scope. Non-exploded
+            # objects flatten under the parameter's own name (`?point=x,1,y,2`).
+            def form_object_value(instance, result, key, schema)
+              params = parse_query(instance["query"]&.value)
+              explode = result.sibling(instance, "explode")&.annotation
+              explode = true if explode.nil?
+
+              if explode
+                properties = schema["properties"]
+                return nil unless properties.respond_to?(:each)
+
+                object = {}
+                properties.each do |property, _subschema|
+                  values = params[property]
+                  object[property] = values.last unless values.nil?
+                end
+                return nil if object.empty?
+
+                Instance::Attribute.new(object, key: key, parent: instance["query"])
+              else
+                values = params[key]
+                return nil if values.nil? || values.last.nil?
+
+                members = values.last.split(",").each_slice(2).to_a
+                # A malformed flattening (odd member count) stays a raw string
+                # so schema validation rejects it.
+                value = (members.all? { |pair| pair.size == 2 }) ? members.to_h : values.last
+                Instance::Attribute.new(value, key: key, parent: instance["query"])
+              end
             end
 
             def parse_query(query_string)

--- a/spec/openapi_test_suite/path_object_params.json
+++ b/spec/openapi_test_suite/path_object_params.json
@@ -1,0 +1,239 @@
+[
+  {
+    "description": "object-valued path params deserialize simple style",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/points/{point}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "point",
+                "required": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"}
+                  },
+                  "required": ["x", "y"]
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "comma-interleaved pairs build a coerced object",
+        "data": {
+          "method": "get",
+          "path": "/points/x,1,y,2",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a missing required property is invalid",
+        "data": {
+          "method": "get",
+          "path": "/points/x,1",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "an odd member count is invalid",
+        "data": {
+          "method": "get",
+          "path": "/points/x,1,y",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "object-valued path params deserialize exploded simple style",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/points/{point}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "point",
+                "required": true,
+                "explode": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"}
+                  },
+                  "required": ["x", "y"]
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "equals-joined pairs build a coerced object",
+        "data": {
+          "method": "get",
+          "path": "/points/x=1,y=2",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a non-integer property is invalid",
+        "data": {
+          "method": "get",
+          "path": "/points/x=a,y=2",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "object-valued path params deserialize label and matrix styles",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/labeled/{point}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "point",
+                "required": true,
+                "style": "label",
+                "explode": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"}
+                  },
+                  "required": ["x", "y"]
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        },
+        "/matrixed/{point}": {
+          "get": {
+            "parameters": [
+              {
+                "in": "path",
+                "name": "point",
+                "required": true,
+                "style": "matrix",
+                "explode": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"}
+                  },
+                  "required": ["x", "y"]
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "exploded label pairs build a coerced object",
+        "data": {
+          "method": "get",
+          "path": "/labeled/.x=1.y=2",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "exploded matrix pairs build a coerced object",
+        "data": {
+          "method": "get",
+          "path": "/matrixed/;x=1;y=2",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      }
+    ]
+  }
+]

--- a/spec/openapi_test_suite/query_form_object_params.json
+++ b/spec/openapi_test_suite/query_form_object_params.json
@@ -1,0 +1,167 @@
+[
+  {
+    "description": "exploded form object query params gather declared properties",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "point",
+                "required": true,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"}
+                  },
+                  "required": ["x", "y"]
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "properties become top-level query keys and are coerced",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "x=1&y=2",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a missing required property is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "x=1",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "no matching properties means the required param is absent",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "unrelated=1",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "non-exploded form object query params flatten under their own name",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/": {
+          "get": {
+            "parameters": [
+              {
+                "in": "query",
+                "name": "point",
+                "required": true,
+                "explode": false,
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"}
+                  },
+                  "required": ["x", "y"]
+                }
+              }
+            ],
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "comma-interleaved members build a coerced object",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "point=x,1,y,2",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "an odd member count is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "point=x,1,y",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a non-integer member is invalid",
+        "data": {
+          "method": "get",
+          "path": "/",
+          "request": {
+            "query": "point=x,a,y,2",
+            "headers": {"Content-Type": "application/json"}
+          },
+          "response": {
+            "status": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Follow-up to #58 completing the object side of parameter deserialization — the last "object-valued path and form-encoded query parameters" roadmap item.

**Path parameters** — objects flatten into the path segment across all three styles:

| style | explode | segment |
|---|---|---|
| `simple` | false | `/points/x,1,y,2` |
| `simple` | true | `/points/x=1,y=2` |
| `label` | true | `/points/.x=1.y=2` |
| `matrix` | true | `/points/;x=1;y=2` |

**Query parameters** — `form`-style objects (the default style):

- `explode: true` (the default): the parameter name disappears — each property declared in the schema becomes its own query key (`?x=1&y=2`). Members are gathered by matching the schema's `properties` names.
- `explode: false`: flattened under the parameter's own name (`?point=x,1,y,2`).

Properties are coerced via the existing `deep_coerce` path (so `properties`/`additionalProperties` typing applies). Internally, `ValueParser` now receives the parameter schema and derives the value shape (`:array`/`:object`/`:primitive`) itself, replacing the `array:` boolean threading.

## Documented limits

- Exploded form objects can only gather members declared in `properties` — `additionalProperties`-only members are unrecognizable by construction (any query key could belong to them). Noted in README.
- Malformed flattenings (odd member counts, missing `=`) stay raw strings so schema validation rejects them rather than crashing.
- Object-valued **header** and **cookie** parameters remain out of scope.

## Test plan

- Two new fixture files: `path_object_params.json` (simple/label/matrix × explode, missing-required, odd-member-count, bad-type cases) and `query_form_object_params.json` (explode gathering, absent-param-required, flattened members, malformed counts).
- Full suite: 616 examples, 0 failures; standardrb clean.
- The shape refactor is behavior-neutral: the pre-existing 562 examples pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)