### PR TITLE
Allow custom coverage stores in RSpec/Minitest helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- Allow passing a custom coverage store to the RSpec/Minitest helpers via `coverage_store:` — any object implementing `load_data`, `save_data`, and `clear`. Useful for writing one coverage file per parallel CI runner and merging afterwards. ([@skryukov])
 - Support object-valued path parameters (`simple`, `label`, and `matrix` styles, explode-aware) and `form`-style object query parameters. Exploded form objects (`?x=1&y=2`) are gathered by matching the schema's `properties` names; non-exploded forms flatten under the parameter's name (`?point=x,1,y,2`). Properties are coerced to their declared types. ([@skryukov])
 
 - Support for external `$ref`s in OpenAPI documents. References like `$ref: './responses.yaml#/UsersResponse'` now resolve against the spec file's directory (or any source registered on the registry) and are wrapped with the appropriate OpenAPI object type — Response, Parameter, Header, RequestBody, PathItem, or a plain JSON Schema for `schema:` refs. Chained and self-recursive external refs are supported. ([@skryukov])

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ RSpec.configure do |config|
   # To enable coverage, pass `coverage: :report` option,
   # and to raise an error when an operation is not covered, pass `coverage: :strict` option:
   config.include Skooma::RSpec[path_to_openapi, coverage: :report], type: :request
+
+  # To control where coverage data is stored (e.g. one file per parallel CI runner),
+  # pass a custom store via `coverage_store:` — any object implementing
+  # `load_data`, `save_data(defined, covered)`, and `clear` works:
+  store = Skooma::CoverageStore.new(file_path: "tmp/skooma_coverage_#{ENV["TEST_ENV_NUMBER"]}.json")
+  config.include Skooma::RSpec[path_to_openapi, coverage: :report, coverage_store: store], type: :request
 end
 ```
 
@@ -128,6 +134,10 @@ ActionDispatch::IntegrationTest.include Skooma::Minitest[path_to_openapi, path_p
 # To enable coverage, pass `coverage: :report` option,
 # and to raise an error when an operation is not covered, pass `coverage: :strict` option:
 ActionDispatch::IntegrationTest.include Skooma::Minitest[path_to_openapi, coverage: :report], type: :request
+
+# To control where coverage data is stored, pass a custom store via `coverage_store:`:
+store = Skooma::CoverageStore.new(file_path: "tmp/skooma_coverage_#{ENV["TEST_ENV_NUMBER"]}.json")
+ActionDispatch::IntegrationTest.include Skooma::Minitest[path_to_openapi, coverage: :report, coverage_store: store], type: :request
 
 # EXPERIMENTAL
 # To enable support for readOnly and writeOnly keywords, pass `enforce_access_modes: true` option:

--- a/lib/skooma/matchers/wrapper.rb
+++ b/lib/skooma/matchers/wrapper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "digest"
 require "pathname"
 
 module Skooma
@@ -44,7 +45,7 @@ module Skooma
         end
       end
 
-      def initialize(helper_methods_module, openapi_path, base_uri: "https://skoomarb.dev/", path_prefix: "", enforce_access_modes: false, use_patterns_for_path_matching: false, **params)
+      def initialize(helper_methods_module, openapi_path, base_uri: "https://skoomarb.dev/", path_prefix: "", enforce_access_modes: false, use_patterns_for_path_matching: false, coverage_store: nil, **params)
         super()
 
         registry = create_test_registry
@@ -59,7 +60,10 @@ module Skooma
         @schema.path_prefix = path_prefix
         @schema.enforce_access_modes = enforce_access_modes
 
-        storage = Skooma::CoverageStore.new(
+        # Any object implementing CoverageStore's interface (load_data,
+        # save_data, clear) can be passed via `coverage_store:` — e.g. to
+        # write one file per parallel CI runner and merge afterwards.
+        storage = coverage_store || Skooma::CoverageStore.new(
           file_path: File.join(Dir.pwd, "tmp", "skooma_coverage_#{Digest::SHA256.hexdigest(source_uri)[0..8]}.json")
         )
         @coverage = Coverage.new(@schema, mode: params[:coverage], format: params[:coverage_format], storage: storage)

--- a/spec/skooma/matchers/wrapper_spec.rb
+++ b/spec/skooma/matchers/wrapper_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+# Minimal store implementing the CoverageStore interface in memory.
+class MemoryCoverageStore
+  attr_reader :defined_paths, :covered_paths
+
+  def initialize
+    @defined_paths = Set.new
+    @covered_paths = Set.new
+  end
+
+  def load_data
+    {defined_paths: Set.new(@defined_paths), covered_paths: Set.new(@covered_paths)}
+  end
+
+  def save_data(new_defined_paths, new_covered_paths)
+    @defined_paths |= new_defined_paths
+    @covered_paths |= new_covered_paths
+  end
+
+  def clear
+    @defined_paths.clear
+    @covered_paths.clear
+  end
+end
+
+RSpec.describe Skooma::Matchers::Wrapper do
+  def write_openapi_doc(dir)
+    path = File.join(dir, "openapi.yaml")
+    File.write(path, <<~YAML)
+      openapi: 3.1.0
+      info: {title: t, version: "1"}
+      paths:
+        /health:
+          get:
+            responses:
+              '200':
+                description: OK
+    YAML
+    path
+  end
+
+  it "uses the coverage store passed via coverage_store:" do
+    Dir.mktmpdir do |dir|
+      store = MemoryCoverageStore.new
+      wrapper = described_class.new(
+        Module.new, write_openapi_doc(dir),
+        base_uri: "https://wrapper-spec.test/custom/",
+        coverage: :report, coverage_store: store
+      )
+
+      expect(wrapper.coverage.storage).to be(store)
+      expect(store.defined_paths).to include(["get", "/health", "200"])
+    end
+  end
+
+  it "defaults to a file-backed CoverageStore" do
+    Dir.mktmpdir do |dir|
+      wrapper = described_class.new(
+        Module.new, write_openapi_doc(dir),
+        base_uri: "https://wrapper-spec.test/default/",
+        coverage: :report
+      )
+
+      storage = wrapper.coverage.storage
+      expect(storage).to be_a(Skooma::CoverageStore)
+      expect(storage.file_path).to include("skooma_coverage_")
+      storage.clear
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #49.

`Matchers::Wrapper` hardcoded a file-backed `CoverageStore` under `tmp/`, so coverage data couldn't be redirected even though `Coverage.new` already accepted any `storage:`. The helpers now accept `coverage_store:`:

```ruby
store = Skooma::CoverageStore.new(file_path: "tmp/skooma_coverage_#{ENV["TEST_ENV_NUMBER"]}.json")
config.include Skooma::RSpec[path_to_openapi, coverage: :report, coverage_store: store], type: :request
```

Any object implementing the store interface (`load_data`, `save_data(defined, covered)`, `clear`) works — covering #49's parallel-CI use case: each runner writes its own file (or a custom adapter persists elsewhere), and a later job merges and reports.

Also fixes a latent bug the new spec exposed: `wrapper.rb` used `Digest::SHA256` without `require "digest"` — it only worked when Rails or rack-test loaded it transitively; the default-store path crashed with `NameError` in a plain RSpec process.

## Test plan

- New `wrapper_spec.rb`: a custom in-memory store is used and receives the defined paths; the default remains a file-backed `CoverageStore`.
- Full suite: 618 examples, 0 failures; standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)