### PR TITLE
Parse multipart and urlencoded request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- Parse `multipart/form-data` and `application/x-www-form-urlencoded` request bodies before validation. File parts are read as binary strings, so uploads validate against `type: string` / `format: binary` schemas. Fixes file upload validation failing with errors like "body id required". ([@skryukov])
 - Allow passing a custom coverage store to the RSpec/Minitest helpers via `coverage_store:` — any object implementing `load_data`, `save_data`, and `clear`. Useful for writing one coverage file per parallel CI runner and merging afterwards. ([@skryukov])
 - Support object-valued path parameters (`simple`, `label`, and `matrix` styles, explode-aware) and `form`-style object query parameters. Exploded form objects (`?x=1&y=2`) are gathered by matching the schema's `properties` names; non-exploded forms flatten under the parameter's name (`?point=x,1,y,2`). Properties are coerced to their declared types. ([@skryukov])
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,27 @@ GET /points/x=1,y=2        # simple, explode:   point => { "x" => 1, "y" => 2 }
 GET /points/;x=1;y=2       # matrix, explode:   point => { "x" => 1, "y" => 2 }
 ```
 
+### Form and multipart request bodies
+
+`application/x-www-form-urlencoded` and `multipart/form-data` request bodies
+are parsed before validation, so file uploads validate against their OpenAPI
+schemas. File parts are read as binary strings, matching
+`type: string` / `format: binary` properties:
+
+```yaml
+requestBody:
+  content:
+    multipart/form-data:
+      schema:
+        type: object
+        properties:
+          id: {type: string}
+          file: {type: string, format: binary}
+```
+
+Custom parsers for other media types can be registered via
+`Skooma::BodyParsers.register("application/xml", ->(body, headers:) { ... })`.
+
 ## Alternatives
 
 - [openapi_first](https://github.com/ahx/openapi_first)

--- a/lib/skooma/body_parsers.rb
+++ b/lib/skooma/body_parsers.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "rack/utils"
+require "rack/multipart"
+
 module Skooma
   module BodyParsers
     class << self
@@ -49,5 +52,58 @@ module Skooma
       end
     end
     register "application/json", JSONParser
+
+    module FormURLEncodedParser
+      def self.call(body, **_options)
+        Rack::Utils.parse_nested_query(body)
+      # The set of parse error classes differs across Rack 2/3; a malformed
+      # body falls back to the raw string so schema validation rejects it.
+      rescue
+        body
+      end
+    end
+    register "application/x-www-form-urlencoded", FormURLEncodedParser
+
+    # Parses multipart bodies with Rack's multipart parser (the boundary is
+    # taken from the request's own Content-Type header). File parts are
+    # replaced by their content read as a binary string, so they validate
+    # against `type: string` / `format: binary` schemas.
+    module MultipartParser
+      def self.call(body, headers: nil, **_options)
+        content_type = headers && headers["Content-Type"]&.value
+        return body if content_type.nil? || body.nil?
+
+        input = StringIO.new(body.to_s.dup.force_encoding(Encoding::BINARY))
+        params = Rack::Multipart.parse_multipart(
+          "CONTENT_TYPE" => content_type,
+          "CONTENT_LENGTH" => input.size.to_s,
+          "rack.input" => input
+        )
+        return body if params.nil?
+
+        simplify(params)
+      # Rack 2/3 raise different errors on malformed multipart (Multipart::Error,
+      # EOFError, ...); fall back to the raw string so validation rejects it.
+      rescue
+        body
+      end
+
+      def self.simplify(value)
+        case value
+        when Hash
+          if value.key?(:tempfile)
+            value[:tempfile].read.force_encoding(Encoding::BINARY)
+          else
+            value.transform_values { |member| simplify(member) }
+          end
+        when Array
+          value.map { |member| simplify(member) }
+        else
+          value
+        end
+      end
+      private_class_method :simplify
+    end
+    register "multipart/form-data", MultipartParser
   end
 end

--- a/spec/openapi_test_suite/form_bodies.json
+++ b/spec/openapi_test_suite/form_bodies.json
@@ -1,0 +1,154 @@
+[
+  {
+    "description": "multipart/form-data request bodies are parsed and validated",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/upload": {
+          "post": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "multipart/form-data": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "id": {"type": "string"},
+                      "file": {"type": "string", "format": "binary"}
+                    },
+                    "required": ["id", "file"]
+                  }
+                }
+              }
+            },
+            "responses": {"201": {"description": "created"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "a body with all required parts is valid",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "--BNDRY\r\nContent-Disposition: form-data; name=\"id\"\r\n\r\n123\r\n--BNDRY\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--BNDRY--\r\n"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a body missing a required part is invalid",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "--BNDRY\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--BNDRY--\r\n"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a malformed multipart body is invalid",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "this is not multipart at all"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "application/x-www-form-urlencoded request bodies are parsed and validated",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/forms": {
+          "post": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "name": {"type": "string"},
+                      "tags": {"type": "array", "items": {"type": "string"}}
+                    },
+                    "required": ["name"]
+                  }
+                }
+              }
+            },
+            "responses": {"201": {"description": "created"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "form fields build an object, including bracketed arrays",
+        "data": {
+          "method": "post",
+          "path": "/forms",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+            "body": "name=Alex&tags[]=a&tags[]=b"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a missing required field is invalid",
+        "data": {
+          "method": "post",
+          "path": "/forms",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+            "body": "tags[]=a"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Closes #16.

`BodyParsers` only registered `application/json`, so `multipart/form-data` and `application/x-www-form-urlencoded` request bodies reached schema validation as raw strings — object schemas then failed with errors like `body id required` (the symptom in #16's ActiveStorage upload scenario).

Two new parsers, built on the `rack` runtime dependency introduced in #55:

- **`application/x-www-form-urlencoded`** via `Rack::Utils.parse_nested_query` (bracketed arrays/nested fields included).
- **`multipart/form-data`** via `Rack::Multipart`, taking the boundary from the request's own `Content-Type` header. File parts are replaced by their content read as a **binary string**, so uploads validate against `type: string` / `format: binary` properties.

Malformed bodies fall back to the raw string so validation rejects them instead of crashing (same contract as the JSON parser); the rescue is intentionally broad because Rack 2 and 3 raise different error classes.

## Test plan

- New `form_bodies.json` fixture: multipart with required file + field (valid / missing part / malformed body) and urlencoded (nested arrays, missing required field).
- Full suite: 637 examples, 0 failures; standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)