### PR TITLE
Respect the encoding field for form request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning].
 ### Added
 
 - Parse `multipart/form-data` and `application/x-www-form-urlencoded` request bodies before validation. File parts are read as binary strings, so uploads validate against `type: string` / `format: binary` schemas. Fixes file upload validation failing with errors like "body id required". ([@skryukov])
+- Respect the Media Type Object's `encoding` field for form bodies: fields with a JSON `contentType` are decoded before validation (multipart object-typed properties default to JSON per the spec). ([@skryukov])
 - Allow passing a custom coverage store to the RSpec/Minitest helpers via `coverage_store:` — any object implementing `load_data`, `save_data`, and `clear`. Useful for writing one coverage file per parallel CI runner and merging afterwards. ([@skryukov])
 - Support object-valued path parameters (`simple`, `label`, and `matrix` styles, explode-aware) and `form`-style object query parameters. Exploded form objects (`?x=1&y=2`) are gathered by matching the schema's `properties` names; non-exploded forms flatten under the parameter's name (`?point=x,1,y,2`). Properties are coerced to their declared types. ([@skryukov])
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ RSpec.configure do |config|
 
   # To control where coverage data is stored (e.g. one file per parallel CI runner),
   # pass a custom store via `coverage_store:` — any object implementing
-  # `load_data`, `save_data(defined, covered)`, and `clear` works:
+  # `load_data`, `save_data(defined, covered)`, and `clear` works.
+  # Treat the path entries as opaque values: their shape may gain dimensions
+  # (e.g. content type) in future versions.
   store = Skooma::CoverageStore.new(file_path: "tmp/skooma_coverage_#{ENV["TEST_ENV_NUMBER"]}.json")
   config.include Skooma::RSpec[path_to_openapi, coverage: :report, coverage_store: store], type: :request
 end
@@ -323,6 +325,23 @@ requestBody:
         properties:
           id: {type: string}
           file: {type: string, format: binary}
+```
+
+The Media Type Object's `encoding` field is respected: a multipart or
+urlencoded field whose `contentType` is a JSON media type is decoded before
+validation, so its schema validates the structured value. For multipart
+bodies, object-typed properties default to JSON decoding per the spec:
+
+```yaml
+content:
+  multipart/form-data:
+    schema:
+      type: object
+      properties:
+        meta: {type: object}          # decoded as JSON (spec default)
+        file: {type: string, format: binary}
+    encoding:
+      meta: {contentType: application/json}
 ```
 
 Custom parsers for other media types can be registered via

--- a/lib/skooma/objects/media_type.rb
+++ b/lib/skooma/objects/media_type.rb
@@ -6,8 +6,86 @@ module Skooma
     class MediaType < Base
       def kw_classes
         [
-          Keywords::OAS31::Schema
+          Keywords::Schema
         ]
+      end
+
+      module Keywords
+        # Applies the Media Type Object's `encoding` field before schema
+        # validation. For `multipart/*` and `application/x-www-form-urlencoded`
+        # bodies, fields arrive as raw strings; a field whose `contentType` is
+        # a JSON media type (explicitly via `encoding`, or by the multipart
+        # default for object-typed properties) is decoded first, so its schema
+        # validates the structured value rather than the serialized string.
+        class Schema < Skooma::Keywords::OAS31::Schema
+          self.key = "schema"
+
+          URLENCODED = "application/x-www-form-urlencoded"
+
+          def evaluate(instance, result)
+            super(apply_encoding(instance), result)
+          end
+
+          private
+
+          def apply_encoding(instance)
+            return instance unless form_media_type?
+
+            value = instance.value
+            return instance unless value.is_a?(Hash)
+
+            encoding = parent_schema["encoding"]
+            decoded = value.each_with_object({}) do |(field, field_value), hash|
+              hash[field] = decode_field(field, field_value, encoding)
+            end
+
+            Instance::Attribute.new(decoded, key: instance.key, parent: instance.parent)
+          end
+
+          def media_type
+            parent_schema.key.to_s.split(";").first.to_s.strip.downcase
+          end
+
+          def form_media_type?
+            media_type.start_with?("multipart/") || media_type == URLENCODED
+          end
+
+          def decode_field(field, value, encoding)
+            content_type = field_content_type(field, encoding)
+            return value unless json_media_type?(content_type)
+
+            parser = BodyParsers[content_type]
+            case value
+            when String
+              parser.call(value)
+            when Array
+              value.map { |item| item.is_a?(String) ? parser.call(item) : item }
+            else
+              value
+            end
+          end
+
+          def field_content_type(field, encoding)
+            explicit = encoding&.[](field)&.[]("contentType")&.value
+            return explicit if explicit
+
+            # The spec's default contentType for multipart object-typed
+            # properties is application/json.
+            return unless media_type.start_with?("multipart/")
+
+            property = json["properties"]&.[](field)
+            return unless property.is_a?(JSONSkooma::JSONSchema)
+
+            "application/json" if property["type"]&.value == "object"
+          end
+
+          def json_media_type?(content_type)
+            return false if content_type.nil?
+
+            normalized = content_type.split(";").first.to_s.strip.downcase
+            normalized == "application/json" || normalized.end_with?("+json")
+          end
+        end
       end
     end
   end

--- a/spec/openapi_test_suite/form_bodies.json
+++ b/spec/openapi_test_suite/form_bodies.json
@@ -150,5 +150,190 @@
         "valid": false
       }
     ]
+  },
+  {
+    "description": "multipart encoding decodes JSON-typed fields before validation",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/upload": {
+          "post": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "multipart/form-data": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "meta": {
+                        "type": "object",
+                        "properties": {"tag": {"type": "string"}},
+                        "required": ["tag"]
+                      },
+                      "config": {"type": "object"},
+                      "file": {"type": "string", "format": "binary"}
+                    },
+                    "required": ["meta", "file"]
+                  },
+                  "encoding": {
+                    "meta": {"contentType": "application/vnd.acme+json"}
+                  }
+                }
+              }
+            },
+            "responses": {"201": {"description": "created"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "an explicitly encoded field is JSON-decoded and validated",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "--BNDRY\r\nContent-Disposition: form-data; name=\"meta\"\r\nContent-Type: application/vnd.acme+json\r\n\r\n{\"tag\": \"x\"}\r\n--BNDRY\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhi\r\n--BNDRY--\r\n"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a decoded field failing its schema is invalid",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "--BNDRY\r\nContent-Disposition: form-data; name=\"meta\"\r\nContent-Type: application/vnd.acme+json\r\n\r\n{\"other\": 1}\r\n--BNDRY\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhi\r\n--BNDRY--\r\n"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "a malformed JSON field stays a string and is invalid",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "--BNDRY\r\nContent-Disposition: form-data; name=\"meta\"\r\nContent-Type: application/vnd.acme+json\r\n\r\n{broken\r\n--BNDRY\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhi\r\n--BNDRY--\r\n"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "object-typed properties default to JSON decoding without explicit encoding",
+        "data": {
+          "method": "post",
+          "path": "/upload",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "multipart/form-data; boundary=BNDRY"},
+            "body": "--BNDRY\r\nContent-Disposition: form-data; name=\"meta\"\r\nContent-Type: application/vnd.acme+json\r\n\r\n{\"tag\": \"x\"}\r\n--BNDRY\r\nContent-Disposition: form-data; name=\"config\"\r\n\r\n{\"theme\": \"dark\"}\r\n--BNDRY\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\nContent-Type: text/plain\r\n\r\nhi\r\n--BNDRY--\r\n"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "urlencoded encoding decodes JSON-typed fields before validation",
+    "schema": {
+      "openapi": "3.1.0",
+      "info": {"title": "api", "version": "1.0.0"},
+      "paths": {
+        "/forms": {
+          "post": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/x-www-form-urlencoded": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "name": {"type": "string"},
+                      "filter": {
+                        "type": "object",
+                        "properties": {"id": {"type": "integer"}},
+                        "required": ["id"]
+                      }
+                    },
+                    "required": ["name", "filter"]
+                  },
+                  "encoding": {
+                    "filter": {"contentType": "application/json"}
+                  }
+                }
+              }
+            },
+            "responses": {"201": {"description": "created"}}
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "the encoded field is JSON-decoded and validated",
+        "data": {
+          "method": "post",
+          "path": "/forms",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+            "body": "name=Alex&filter=%7B%22id%22%3A%201%7D"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "a decoded field failing its schema is invalid",
+        "data": {
+          "method": "post",
+          "path": "/forms",
+          "request": {
+            "query": "",
+            "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+            "body": "name=Alex&filter=%7B%22id%22%3A%20%22x%22%7D"
+          },
+          "response": {
+            "status": 201,
+            "headers": {"Content-Type": "application/json"},
+            "body": null
+          }
+        },
+        "valid": false
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to #61 completing the multipart story: the Media Type Object's `encoding` field is now respected for `multipart/*` and `application/x-www-form-urlencoded` request bodies.

- A field whose `encoding.<field>.contentType` is a JSON media type (`application/json` or any `+json` suffix) is **decoded before validation**, so its schema validates the structured value rather than the serialized string.
- Multipart **object-typed properties default to `application/json`** per the spec's encoding-defaults table — nested JSON parts validate without any explicit `encoding` declaration.
- Malformed JSON in an encoded field falls back to the raw string and is rejected by schema validation (same contract as everywhere else — never a crash).
- Implemented as a MediaType-level schema keyword: the `encoding` object and the parsed body are both in scope there, mirroring the content-typed-parameter approach from #58. Decoding goes through `BodyParsers`, so registered custom parsers (and the `+json` suffix lookup) apply.

Also adds the agreed `coverage_store:` docs note: path entries are opaque values whose shape may gain dimensions (e.g. content type) in future versions.

## Test plan

- Six new fixture cases in `form_bodies.json`: explicit `contentType` with a vendor `+json` type, decoded-field schema violation, malformed JSON falling through to rejection, the multipart object-property default, and urlencoded encoding (valid + invalid).
- Full suite: 663 examples, 0 failures; standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)